### PR TITLE
Sprint 1: stability fixes (map flash, autocomplete, game end, timezone, tooltip)

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -22,13 +22,14 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 async function initializeGame() {
-  // Set the start date
-  const startDate = new Date('2024-12-16');
-  const currentDate = new Date();
-  
-  // Calculate the difference in days
-  const diffTime = Math.abs(currentDate - startDate);
-  const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+  // Set the start date (local midnight, so the puzzle changes at the
+  // player's local midnight regardless of timezone)
+  const startDate = new Date(2024, 11, 16);
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+
+  // Calculate the difference in days (rounded to absorb DST shifts)
+  const diffDays = Math.round((today - startDate) / (1000 * 60 * 60 * 24));
   
   // Load the precomputed pairs
   const responsePairs = await fetch("pairs.json");
@@ -86,10 +87,10 @@ async function initializeGame() {
   svgElement.querySelectorAll("g").forEach(group => {
     if (group.id === startComarca) {
       setSvgFill(group, getComputedStyle(document.documentElement).getPropertyValue('--start-color'));
+      group.style.display = "inline";
     } else if (group.id === endComarca) {
       setSvgFill(group, getComputedStyle(document.documentElement).getPropertyValue('--end-color'));
-    } else {
-      group.style.display = "none";
+      group.style.display = "inline";
     }
   });
   
@@ -110,7 +111,11 @@ function populateDropdown(svgElement) {
 
   const input = document.getElementById("comarques-input");
   input.addEventListener("input", () => {
-    const query = input.value.toLowerCase();
+    const query = input.value.trim().toLowerCase();
+    if (!query) {
+      dropdown.innerHTML = "";
+      return;
+    }
     const suggestions = comarques
       .filter(c => c.name.toLowerCase().includes(query))
       .map(c => `<button type="button" class="dropdown-item" data-id="${c.id}">${c.name}</button>`)
@@ -127,34 +132,35 @@ function populateDropdown(svgElement) {
   });
 }
 
-// Tooltip handling logic by BinariEM 
-var mapa = document.getElementById("map-container")
-mapa.addEventListener('mouseover', function (e) {
-		
-  var dataComarca = e.target.getAttribute("data-comarca"); // Guardem el nom de la classe en una variable
+// Tooltip handling logic by BinariEM
+const mapa = document.getElementById("map-container");
+const tooltip = document.getElementById("tooltip");
+
+mapa.addEventListener("mouseover", (e) => {
+  const dataComarca = e.target.getAttribute("data-comarca");
   if (dataComarca) {
-    document.getElementById('tooltip').style.display="block"; // Mostrem la capa
-    
-    var contenidor = document.getElementById("tooltip"); // Agafem la capa contenidor
-    contenidor.innerHTML = "<span class='triangle'></span>" + "<div>"+ dataComarca+"</div>"; // Afegim la informació
-    
-    // Amagar quan mouseout
-    document.addEventListener('mouseout', function (f) {
-      document.getElementById('tooltip').style.display="none"; // Amagem la capa
-    });
-  
-    // Seguiment del cursor
-    var tooltip = document.getElementById('tooltip');
-    window.onmousemove = function(s) {
-      var x = s.pageX, y = s.pageY;
-      tooltip.style.left = (x + 20) + 'px';
-      tooltip.style.top = (y - 20) + 'px';
-    };
+    tooltip.innerHTML = "<span class='triangle'></span>" + "<div>" + dataComarca + "</div>";
+    tooltip.style.display = "block";
+  } else {
+    tooltip.style.display = "none";
   }
+});
+
+mapa.addEventListener("mouseleave", () => {
+  tooltip.style.display = "none";
+});
+
+mapa.addEventListener("mousemove", (e) => {
+  tooltip.style.left = (e.pageX + 20) + "px";
+  tooltip.style.top = (e.pageY - 20) + "px";
 });
 
 // Guess handling logic update
 document.getElementById("btn-guess").addEventListener("click", () => {
+  if (!game_state.game_running) {
+      return;
+  }
+
   const guess = document.getElementById("comarques-input").value.trim();
   const svgElement = document.querySelector("svg");
   const comarca = Array.from(svgElement.querySelectorAll("g")).find(
@@ -182,11 +188,11 @@ document.getElementById("btn-guess").addEventListener("click", () => {
   if (guessIcon === game_state.guesses_icons.bad) {
       incorrectGuesses++;
       if (incorrectGuesses >= maxIncorrectGuesses) {
-          showFeedback("You lost! Try again tomorrow.", "red");
+          endGame("You lost! Try again tomorrow.", "red");
           return;
       }
   } else if (shortestPaths.some(path => path.length === 0)) {
-    showFeedback("You won! Congratulations!", "green");
+    endGame("You won! Congratulations!", "green");
     return;
   }
 
@@ -200,6 +206,13 @@ function showFeedback(message, color) {
   const feedback = document.getElementById("feedback");
   feedback.textContent = message;
   feedback.style.color = color;
+}
+
+function endGame(message, color) {
+  game_state.game_running = false;
+  showFeedback(message, color);
+  document.getElementById("comarques-input").disabled = true;
+  document.getElementById("btn-guess").disabled = true;
 }
 
 function updateGuessButton() {

--- a/src/styles.css
+++ b/src/styles.css
@@ -42,6 +42,12 @@ h1 {
   margin-bottom: 10px;
 }
 
+/* Comarques start hidden so the full map is never visible while loading;
+   the game reveals them explicitly (issue #22) */
+#map-container svg g {
+  display: none;
+}
+
 input {
   width: 60%;
   padding: 10px;


### PR DESCRIPTION
## What

Five small stability fixes, verified end-to-end by playing full win and loss games in the browser.

### Bug fixes
- **#22 — full map flash on load**: all comarques are now hidden by a CSS rule (`#map-container svg g { display: none }`) instead of being hidden by JS *after* the SVG is injected, so the answer space is never visible, regardless of network timing. `initializeGame()` explicitly reveals start/end.
- **#16 — autocomplete shows everything on empty input**: empty/whitespace input now clears the suggestion list instead of matching every comarca.

### Tech debt
- **Game never actually ended**: after "You won!"/"You lost!" the guess button stayed active. New `endGame()` sets `game_state.game_running = false`, disables the input and button, and the click handler guards on it.
- **Timezone bug in daily puzzle selection**: `new Date('2024-12-16')` parses as UTC midnight while the current time is local, so the puzzle switched at 01:00/02:00 local (CET/CEST) rather than midnight, and `Math.abs` masked clock skew. Day index is now computed from local midnights with `Math.round` to absorb DST shifts. Verified the index is unchanged for today (578).
- **Tooltip listener leak**: every hover registered an extra document-level `mouseout` listener and reassigned `window.onmousemove`. Listeners are now registered once on the map container.

## Verification (played in Chrome against a local server)

- Load: only start (Cerdanya, pink) and end (Alcalatén, blue) visible; unrevealed comarques have no inline style and compute to `display: none` from CSS alone.
- Typed "emp" → only Baix/Alt Empordà suggested; cleared input → no suggestions.
- Played a full win (1 bad guess + 6 optimal): route rendered green, "You won!", input+button disabled, further clicks ignored.
- Played a full loss (5 bad guesses): "You lost!", game locked, extra button clicks don't change state.
- Duplicate guess → "Already guessed!" without consuming a guess; garbage input → "Invalid comarca!".
- Tooltip appears on hover over a comarca and hides over empty map / on leaving the map.
- Recomputed the local-midnight day index in-page and confirmed it selects the same pair the game loaded.

Closes #22
Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)