### PR TITLE
Sprint 3a: map pan & zoom (#1)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -34,6 +34,7 @@
     <div id='tooltip'></div>   
   </div>
 
+  <script src="panzoom.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/src/panzoom.js
+++ b/src/panzoom.js
@@ -1,0 +1,131 @@
+// Pan & zoom for the map SVG by manipulating its viewBox.
+// Uses Pointer Events so mouse drag, touch drag and pinch all work the
+// same way, plus wheel zoom, double click/tap zoom and on-screen buttons.
+function initPanZoom(svgElement, container) {
+  const [fullX, fullY, fullW, fullH] = svgElement
+    .getAttribute("viewBox")
+    .split(/\s+/)
+    .map(Number);
+  const MAX_ZOOM = 8;
+  const WHEEL_STEP = 1.2;
+
+  const vb = { x: fullX, y: fullY, w: fullW, h: fullH };
+  const pointers = new Map(); // active pointerId -> {x, y}
+  let pinchDistance = 0;
+
+  function applyViewBox() {
+    svgElement.setAttribute("viewBox", `${vb.x} ${vb.y} ${vb.w} ${vb.h}`);
+  }
+
+  // Keep the view inside the original map bounds
+  function clampPan() {
+    vb.x = Math.min(Math.max(vb.x, fullX), fullX + fullW - vb.w);
+    vb.y = Math.min(Math.max(vb.y, fullY), fullY + fullH - vb.h);
+  }
+
+  function toSvgPoint(clientX, clientY) {
+    const rect = svgElement.getBoundingClientRect();
+    return {
+      x: vb.x + ((clientX - rect.left) / rect.width) * vb.w,
+      y: vb.y + ((clientY - rect.top) / rect.height) * vb.h,
+    };
+  }
+
+  // Zoom by `factor` (>1 zooms out, <1 zooms in) keeping `point` fixed
+  function zoomAt(point, factor) {
+    const targetW = Math.min(Math.max(vb.w * factor, fullW / MAX_ZOOM), fullW);
+    const f = targetW / vb.w;
+    vb.x = point.x - (point.x - vb.x) * f;
+    vb.y = point.y - (point.y - vb.y) * f;
+    vb.w *= f;
+    vb.h *= f;
+    clampPan();
+    applyViewBox();
+  }
+
+  function zoomAtCenter(factor) {
+    zoomAt({ x: vb.x + vb.w / 2, y: vb.y + vb.h / 2 }, factor);
+  }
+
+  function reset() {
+    vb.x = fullX;
+    vb.y = fullY;
+    vb.w = fullW;
+    vb.h = fullH;
+    applyViewBox();
+  }
+
+  container.addEventListener("wheel", (e) => {
+    e.preventDefault();
+    zoomAt(toSvgPoint(e.clientX, e.clientY), e.deltaY > 0 ? WHEEL_STEP : 1 / WHEEL_STEP);
+  }, { passive: false });
+
+  container.addEventListener("dblclick", (e) => {
+    zoomAt(toSvgPoint(e.clientX, e.clientY), 0.5);
+  });
+
+  container.addEventListener("pointerdown", (e) => {
+    // Leave the zoom buttons alone: capturing their pointer retargets the
+    // resulting click to the container and the buttons never fire
+    if (e.target.closest(".zoom-controls")) {
+      return;
+    }
+    container.setPointerCapture(e.pointerId);
+    pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    pinchDistance = 0;
+  });
+
+  container.addEventListener("pointermove", (e) => {
+    const prev = pointers.get(e.pointerId);
+    if (!prev) {
+      return;
+    }
+    pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    const points = [...pointers.values()];
+    const rect = svgElement.getBoundingClientRect();
+
+    if (points.length === 1) {
+      // Drag to pan
+      vb.x -= ((e.clientX - prev.x) / rect.width) * vb.w;
+      vb.y -= ((e.clientY - prev.y) / rect.height) * vb.h;
+      clampPan();
+      applyViewBox();
+    } else if (points.length === 2) {
+      // Pinch to zoom around the midpoint
+      const [a, b] = points;
+      const distance = Math.hypot(a.x - b.x, a.y - b.y);
+      if (pinchDistance > 0) {
+        const mid = toSvgPoint((a.x + b.x) / 2, (a.y + b.y) / 2);
+        zoomAt(mid, pinchDistance / distance);
+      }
+      pinchDistance = distance;
+    }
+  });
+
+  function releasePointer(e) {
+    if (container.hasPointerCapture(e.pointerId)) {
+      container.releasePointerCapture(e.pointerId);
+    }
+    pointers.delete(e.pointerId);
+    pinchDistance = 0;
+  }
+  container.addEventListener("pointerup", releasePointer);
+  container.addEventListener("pointercancel", releasePointer);
+
+  // On-screen controls (also the only zoom UI on desktop without a wheel)
+  const controls = document.createElement("div");
+  controls.className = "zoom-controls";
+  [
+    ["+", "Zoom in", () => zoomAtCenter(1 / WHEEL_STEP ** 2)],
+    ["−", "Zoom out", () => zoomAtCenter(WHEEL_STEP ** 2)],
+    ["⛶", "Reset zoom", reset],
+  ].forEach(([label, title, onClick]) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = label;
+    button.title = title;
+    button.addEventListener("click", onClick);
+    controls.appendChild(button);
+  });
+  container.appendChild(controls);
+}

--- a/src/script.js
+++ b/src/script.js
@@ -85,6 +85,7 @@ async function initializeGame() {
   });
 
   populateDropdown(svgElement);
+  initPanZoom(svgElement, document.getElementById("map-container"));
   document.getElementById("start-comarca").textContent = getComarcaName(game_state.start, svgElement);
   document.getElementById("end-comarca").textContent = getComarcaName(game_state.end, svgElement);
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -40,6 +40,33 @@ h1 {
   position: relative;
   background-color: white;
   margin-bottom: 10px;
+  /* Let the pan/pinch pointer handlers own all touch gestures on the map */
+  touch-action: none;
+  user-select: none;
+}
+
+.zoom-controls {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.zoom-controls button {
+  width: 34px;
+  height: 34px;
+  font-size: 1.1rem;
+  line-height: 1;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: #ffffffcc;
+  cursor: pointer;
+}
+
+.zoom-controls button:hover {
+  background-color: #f0f0f0;
 }
 
 /* Comarques start hidden so the full map is never visible while loading;


### PR DESCRIPTION
Stacked on #25 (base is `sprint-1-stability-fixes` so the diff shows only the zoom work; it will retarget to `main` automatically if the branch is deleted when #25 merges).

## What

- **`src/panzoom.js` (new, dependency-free)** — pan & zoom by manipulating the SVG `viewBox`:
  - Pointer Events give mouse drag, touch drag, and two-finger pinch one shared code path (this is why I didn't vendor `svg-pan-zoom`: it needs Hammer.js on top for pinch, i.e. two libraries for what ~130 lines cover natively).
  - Wheel zoom and double click/tap zoom anchored at the cursor.
  - `+ / − / ⛶` buttons overlaid top-right (the only zoom UI for mouse users without a wheel, and a discoverable affordance on mobile).
  - Zoom clamped between the full map and 8×; pan clamped to the map bounds.
- `touch-action: none` + `user-select: none` on the map container so the browser hands gestures to the handlers.
- `initializeGame()` calls `initPanZoom()` after the SVG is injected.

## Verification (driven in Chrome)

- Wheel zoom anchors at the cursor; drag pans by exactly the drag distance; double click zooms in 2×.
- `+`/`−` buttons zoom around the center; `⛶` resets to the full map.
- Clamps hold: zoom-out and pan at full view are no-ops; repeated zoom-in stops at exactly `viewBox` width 74.4125 (= 595.3/8).
- Found & fixed during verification: pointer capture on `pointerdown` retargeted button clicks to the container, so the zoom buttons fired only intermittently — capture now skips the controls and is explicitly released on pointerup.
- Gameplay unaffected while zoomed: tooltip tracks correctly and a guess reveals the comarca at the zoomed view without resetting it.

Not exercised: real touch pinch (verified with synthesized pointer math only) — worth a quick thumb-test on a phone after deploy.

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)