### PR TITLE
Sprint 3b: progressive hints (#17)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -20,6 +20,7 @@
       <div class="dropdown-menu" id="autocomplete-list"></div>
       <input id="comarques-input" class="form-control input-lg dropdown-toggle" placeholder="Enter a comarca..." aria-describedby="btn-guess" data-bs-toggle="dropdown">
       <button id="btn-guess" class="btn btn-outline-success btn-lg guess-button" type="button">Guess</button>
+      <button id="btn-hint" class="hint-button" type="button" title="Use a hint (costs one guess)">💡 (3)</button>
 
 
     </div>

--- a/src/script.js
+++ b/src/script.js
@@ -63,7 +63,9 @@ async function initializeGame() {
     max_guesses: shortestPaths[0].length + maxIncorrectGuesses,
     guessed_ids: [],
     guesses_status: [],
+    events: [],
     incorrect_guesses: 0,
+    hints_used: 0,
     game_running: true,
     guesses_icons: {
       optimal: "✅",
@@ -91,13 +93,14 @@ async function initializeGame() {
 
   restoreProgress(svgElement);
   updateGuessButton();
+  updateHintButton();
 }
 
 function saveProgress() {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({
       day: game_state.day,
-      guessed_ids: game_state.guessed_ids
+      events: game_state.events
     }));
   } catch (err) {
     // Storage unavailable (private mode, quota); the game still works, it
@@ -112,16 +115,29 @@ function restoreProgress(svgElement) {
   } catch (err) {
     return;
   }
-  if (!saved || saved.day !== game_state.day || !Array.isArray(saved.guessed_ids)) {
+  if (!saved || saved.day !== game_state.day) {
     return;
   }
-  for (const comarcaId of saved.guessed_ids) {
-    if (!game_state.game_running || !/^[a-z_]+$/.test(comarcaId)) {
+  // Older saves stored a plain list of guessed ids; convert to events
+  const events = Array.isArray(saved.events)
+    ? saved.events
+    : Array.isArray(saved.guessed_ids)
+      ? saved.guessed_ids.map(id => ({ t: "g", id: id }))
+      : null;
+  if (!events) {
+    return;
+  }
+  for (const event of events) {
+    if (!game_state.game_running) {
       break;
     }
-    const comarca = svgElement.querySelector(`g#${comarcaId}`);
-    if (comarca) {
-      applyGuess(comarca, false);
+    if (event.t === "h") {
+      applyHint(false);
+    } else if (event.t === "g" && /^[a-z_]+$/.test(event.id)) {
+      const comarca = svgElement.querySelector(`g#${event.id}`);
+      if (comarca) {
+        applyGuess(comarca, false);
+      }
     }
   }
 }
@@ -210,10 +226,12 @@ document.getElementById("btn-guess").addEventListener("click", () => {
 
 function applyGuess(comarca, save = true) {
   // Reveal comarca and apply color based on correctness
+  clearHintMarks(comarca);
   comarca.style.display = "inline";
   const guessIcon = checkGuess(comarca.id);
   game_state.guessed_ids.push(comarca.id);
   game_state.guesses_status.push(guessIcon);
+  game_state.events.push({ t: "g", id: comarca.id });
   updateGuessHistory(comarca.getAttribute("data-comarca"), guessIcon);
   if (save) {
     saveProgress();
@@ -231,7 +249,119 @@ function applyGuess(comarca, save = true) {
     return;
   }
 
+  checkOutOfGuesses();
   updateGuessButton();
+}
+
+// Progressive hints (issue #17): each hint costs one guess slot.
+// Level 1 outlines the next optimal comarca, level 2 outlines every
+// comarca still on a shortest path, level 3 adds their initials.
+const maxHints = 3;
+
+function applyHint(save = true) {
+  if (!game_state.game_running || game_state.hints_used >= maxHints) {
+    return;
+  }
+  const svgElement = document.querySelector("svg");
+  game_state.hints_used++;
+
+  let description;
+  if (game_state.hints_used === 1) {
+    outlineComarca(svgElement.querySelector(`g#${game_state.shortests_paths[0][0]}`));
+    description = "Next comarca outlined";
+  } else if (game_state.hints_used === 2) {
+    remainingPathIds().forEach(id => outlineComarca(svgElement.querySelector(`g#${id}`)));
+    description = "All path comarques outlined";
+  } else {
+    remainingPathIds().forEach(id => {
+      const group = svgElement.querySelector(`g#${id}`);
+      outlineComarca(group);
+      addInitials(group);
+    });
+    description = "Path initials shown";
+  }
+
+  game_state.guesses_status.push("💡");
+  game_state.events.push({ t: "h" });
+  updateGuessHistory(description, "💡");
+  if (save) {
+    saveProgress();
+  }
+
+  updateHintButton();
+  checkOutOfGuesses();
+  updateGuessButton();
+}
+
+// Every comarca still left on any shortest path (guessed ones are
+// spliced out by checkGuess)
+function remainingPathIds() {
+  return [...new Set(game_state.shortests_paths.flat())];
+}
+
+function outlineComarca(group) {
+  const shape = group.querySelector("polygon") || group.querySelector("path");
+  if (shape && !shape.dataset.hintOutlined) {
+    // The original fill lives in the shape's inline style attribute, so
+    // remember it to restore when the comarca is guessed
+    shape.dataset.hintOutlined = "true";
+    shape.dataset.prevFill = shape.style.fill;
+    shape.style.fill = "none";
+    shape.style.strokeDasharray = "3 2";
+  }
+  group.style.display = "inline";
+}
+
+function addInitials(group) {
+  if (group.querySelector("text.hint-initials")) {
+    return;
+  }
+  const shape = group.querySelector("polygon") || group.querySelector("path");
+  const bbox = shape.getBBox();
+  const initials = group.getAttribute("data-comarca")
+    .split(/\s+/)
+    .map(word => word[0].toUpperCase())
+    .join("");
+  const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
+  text.setAttribute("x", bbox.x + bbox.width / 2);
+  text.setAttribute("y", bbox.y + bbox.height / 2);
+  text.setAttribute("class", "hint-initials");
+  text.textContent = initials;
+  group.appendChild(text);
+}
+
+// Undo hint styling once the comarca is actually guessed
+function clearHintMarks(comarca) {
+  const shape = comarca.querySelector("polygon") || comarca.querySelector("path");
+  if (shape && shape.dataset.hintOutlined) {
+    shape.style.fill = shape.dataset.prevFill;
+    shape.style.strokeDasharray = "";
+    delete shape.dataset.hintOutlined;
+    delete shape.dataset.prevFill;
+  }
+  const initials = comarca.querySelector("text.hint-initials");
+  if (initials) {
+    initials.remove();
+  }
+}
+
+function usedGuesses() {
+  return game_state.guessed_ids.length + game_state.hints_used;
+}
+
+function checkOutOfGuesses() {
+  if (game_state.game_running && usedGuesses() >= game_state.max_guesses) {
+    endGame("Out of guesses! Try again tomorrow.", "red");
+  }
+}
+
+document.getElementById("btn-hint").addEventListener("click", () => applyHint());
+
+function updateHintButton() {
+  const button = document.getElementById("btn-hint");
+  const hintsLeft = maxHints - game_state.hints_used;
+  button.textContent = `💡 (${hintsLeft})`;
+  button.disabled = hintsLeft === 0 || !game_state.game_running;
 }
 
 function showFeedback(message, color) {
@@ -245,13 +375,14 @@ function endGame(message, color) {
   showFeedback(message, color);
   document.getElementById("comarques-input").disabled = true;
   document.getElementById("btn-guess").disabled = true;
+  document.getElementById("btn-hint").disabled = true;
   document.getElementById("btn-share").hidden = false;
 }
 
 function buildShareText() {
   const gameNumber = game_state.day + 1;
   const won = game_state.shortests_paths.some(path => path.length === 0);
-  const extraGuesses = game_state.guessed_ids.length - game_state.shortest_path_length;
+  const extraGuesses = usedGuesses() - game_state.shortest_path_length;
   const score = won ? `+${extraGuesses}` : "X";
   return `#viatgle #${gameNumber} ${score}\n${game_state.guesses_status.join("")}\n${GAME_URL}`;
 }
@@ -274,7 +405,7 @@ function updateGuessButton() {
   if (!game_state.game_running) {
     return;
   }
-  document.getElementById("btn-guess").textContent = `Guess (${game_state.guessed_ids.length + 1}/${game_state.max_guesses})`;
+  document.getElementById("btn-guess").textContent = `Guess (${usedGuesses() + 1}/${game_state.max_guesses})`;
 }
 
 function getComarcaName(comarcaId, svgElement) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -92,6 +92,28 @@ button.guess-button {
   margin-top: 10px;
 }
 
+button.hint-button {
+  margin-left: 10px;
+  padding: 10px 10px;
+  cursor: pointer;
+}
+
+button.hint-button:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+/* Initials drawn on outlined comarques by the third hint */
+.hint-initials {
+  font-family: Arial, sans-serif;
+  font-size: 10px;
+  font-weight: bold;
+  fill: #555;
+  text-anchor: middle;
+  dominant-baseline: middle;
+  pointer-events: none;
+}
+
 button.share-button {
   padding: 10px 20px;
   margin-bottom: 10px;


### PR DESCRIPTION
Stacked on #26 (base `sprint-3-zoom`).

## What

Implements the three hints from #17 as a progressive ladder on a single 💡 button:

1. **Next comarca outline** — the next optimal step appears as a dashed, unfilled outline.
2. **All comarca outlines** — every comarca still on any shortest path gets outlined.
3. **Comarca initials** — outlined comarques get their initials drawn at their center (`getBBox()` + SVG `<text>`).

Design decisions:
- **Each hint costs one guess slot.** The guess counter counts hints, the share string's `+N` includes them, and each hint adds a 💡 to the emoji sequence — so a hint-assisted win is visibly different when shared.
- **Out-of-guesses loss condition (new).** The `n/max` budget was never actually enforced — you could keep guessing adjacent (🟧) comarques forever. With hints consuming slots this became reachable, so exhausting the budget now ends the game with "Out of guesses!".
- **Persistence format upgraded** from `{guessed_ids: [...]}` to an ordered `{events: [{t:'g',id}|{t:'h'}]}` list, because hint effects depend on when they happen relative to guesses. Old-format saves are converted on load.
- When an outlined comarca is guessed, its hint marks are removed and the guess color takes over.

## Verification (played in Chrome)

- Hint 1 → next optimal comarca (Alt Urgell) shows dashed with no fill; counter jumps to 2/11; 💡 chip in history.
- Hints 2+3 → all 8 remaining path comarques outlined, initials (AU, N, S, M, BM, AM, P, PA) rendered at their centers; button reads 💡 (0) and disables.
- Reload mid-game → all three hints replay: outlines, initials, counter, disabled hint button all restored.
- Guessing the outlined comarca clears the dash/initials and fills it green.
- Drove a full game to 11/11 used (3 hints + 1 ✅ + 4 🟥 + 3 🟧) → "Out of guesses!" ends and locks the game; share text `#viatgle #579 X` / `💡💡💡✅🟥🟥🟥🟥🟧🟧🟧`; state survives reload.
- **Found & fixed while verifying:** clearing hint styling with `style.fill = ""` deleted the fill from the shape's inline `style` attribute, so *unrelated* bad guesses rendered black instead of grey. Outlines now save and restore the original fill, and only touch shapes a hint actually marked.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)