### PR TITLE
Bring Sprint 3 (zoom + hints) into main

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -34,6 +34,7 @@
     <div id='tooltip'></div>   
   </div>
 
+  <script src="panzoom.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -20,6 +20,7 @@
       <div class="dropdown-menu" id="autocomplete-list"></div>
       <input id="comarques-input" class="form-control input-lg dropdown-toggle" placeholder="Enter a comarca..." aria-describedby="btn-guess" data-bs-toggle="dropdown">
       <button id="btn-guess" class="btn btn-outline-success btn-lg guess-button" type="button">Guess</button>
+      <button id="btn-hint" class="hint-button" type="button" title="Use a hint (costs one guess)">💡 (3)</button>
 
 
     </div>

--- a/src/panzoom.js
+++ b/src/panzoom.js
@@ -1,0 +1,131 @@
+// Pan & zoom for the map SVG by manipulating its viewBox.
+// Uses Pointer Events so mouse drag, touch drag and pinch all work the
+// same way, plus wheel zoom, double click/tap zoom and on-screen buttons.
+function initPanZoom(svgElement, container) {
+  const [fullX, fullY, fullW, fullH] = svgElement
+    .getAttribute("viewBox")
+    .split(/\s+/)
+    .map(Number);
+  const MAX_ZOOM = 8;
+  const WHEEL_STEP = 1.2;
+
+  const vb = { x: fullX, y: fullY, w: fullW, h: fullH };
+  const pointers = new Map(); // active pointerId -> {x, y}
+  let pinchDistance = 0;
+
+  function applyViewBox() {
+    svgElement.setAttribute("viewBox", `${vb.x} ${vb.y} ${vb.w} ${vb.h}`);
+  }
+
+  // Keep the view inside the original map bounds
+  function clampPan() {
+    vb.x = Math.min(Math.max(vb.x, fullX), fullX + fullW - vb.w);
+    vb.y = Math.min(Math.max(vb.y, fullY), fullY + fullH - vb.h);
+  }
+
+  function toSvgPoint(clientX, clientY) {
+    const rect = svgElement.getBoundingClientRect();
+    return {
+      x: vb.x + ((clientX - rect.left) / rect.width) * vb.w,
+      y: vb.y + ((clientY - rect.top) / rect.height) * vb.h,
+    };
+  }
+
+  // Zoom by `factor` (>1 zooms out, <1 zooms in) keeping `point` fixed
+  function zoomAt(point, factor) {
+    const targetW = Math.min(Math.max(vb.w * factor, fullW / MAX_ZOOM), fullW);
+    const f = targetW / vb.w;
+    vb.x = point.x - (point.x - vb.x) * f;
+    vb.y = point.y - (point.y - vb.y) * f;
+    vb.w *= f;
+    vb.h *= f;
+    clampPan();
+    applyViewBox();
+  }
+
+  function zoomAtCenter(factor) {
+    zoomAt({ x: vb.x + vb.w / 2, y: vb.y + vb.h / 2 }, factor);
+  }
+
+  function reset() {
+    vb.x = fullX;
+    vb.y = fullY;
+    vb.w = fullW;
+    vb.h = fullH;
+    applyViewBox();
+  }
+
+  container.addEventListener("wheel", (e) => {
+    e.preventDefault();
+    zoomAt(toSvgPoint(e.clientX, e.clientY), e.deltaY > 0 ? WHEEL_STEP : 1 / WHEEL_STEP);
+  }, { passive: false });
+
+  container.addEventListener("dblclick", (e) => {
+    zoomAt(toSvgPoint(e.clientX, e.clientY), 0.5);
+  });
+
+  container.addEventListener("pointerdown", (e) => {
+    // Leave the zoom buttons alone: capturing their pointer retargets the
+    // resulting click to the container and the buttons never fire
+    if (e.target.closest(".zoom-controls")) {
+      return;
+    }
+    container.setPointerCapture(e.pointerId);
+    pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    pinchDistance = 0;
+  });
+
+  container.addEventListener("pointermove", (e) => {
+    const prev = pointers.get(e.pointerId);
+    if (!prev) {
+      return;
+    }
+    pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    const points = [...pointers.values()];
+    const rect = svgElement.getBoundingClientRect();
+
+    if (points.length === 1) {
+      // Drag to pan
+      vb.x -= ((e.clientX - prev.x) / rect.width) * vb.w;
+      vb.y -= ((e.clientY - prev.y) / rect.height) * vb.h;
+      clampPan();
+      applyViewBox();
+    } else if (points.length === 2) {
+      // Pinch to zoom around the midpoint
+      const [a, b] = points;
+      const distance = Math.hypot(a.x - b.x, a.y - b.y);
+      if (pinchDistance > 0) {
+        const mid = toSvgPoint((a.x + b.x) / 2, (a.y + b.y) / 2);
+        zoomAt(mid, pinchDistance / distance);
+      }
+      pinchDistance = distance;
+    }
+  });
+
+  function releasePointer(e) {
+    if (container.hasPointerCapture(e.pointerId)) {
+      container.releasePointerCapture(e.pointerId);
+    }
+    pointers.delete(e.pointerId);
+    pinchDistance = 0;
+  }
+  container.addEventListener("pointerup", releasePointer);
+  container.addEventListener("pointercancel", releasePointer);
+
+  // On-screen controls (also the only zoom UI on desktop without a wheel)
+  const controls = document.createElement("div");
+  controls.className = "zoom-controls";
+  [
+    ["+", "Zoom in", () => zoomAtCenter(1 / WHEEL_STEP ** 2)],
+    ["−", "Zoom out", () => zoomAtCenter(WHEEL_STEP ** 2)],
+    ["⛶", "Reset zoom", reset],
+  ].forEach(([label, title, onClick]) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.textContent = label;
+    button.title = title;
+    button.addEventListener("click", onClick);
+    controls.appendChild(button);
+  });
+  container.appendChild(controls);
+}

--- a/src/script.js
+++ b/src/script.js
@@ -63,7 +63,9 @@ async function initializeGame() {
     max_guesses: shortestPaths[0].length + maxIncorrectGuesses,
     guessed_ids: [],
     guesses_status: [],
+    events: [],
     incorrect_guesses: 0,
+    hints_used: 0,
     game_running: true,
     guesses_icons: {
       optimal: "✅",
@@ -91,13 +93,14 @@ async function initializeGame() {
 
   restoreProgress(svgElement);
   updateGuessButton();
+  updateHintButton();
 }
 
 function saveProgress() {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({
       day: game_state.day,
-      guessed_ids: game_state.guessed_ids
+      events: game_state.events
     }));
   } catch (err) {
     // Storage unavailable (private mode, quota); the game still works, it
@@ -112,16 +115,29 @@ function restoreProgress(svgElement) {
   } catch (err) {
     return;
   }
-  if (!saved || saved.day !== game_state.day || !Array.isArray(saved.guessed_ids)) {
+  if (!saved || saved.day !== game_state.day) {
     return;
   }
-  for (const comarcaId of saved.guessed_ids) {
-    if (!game_state.game_running || !/^[a-z_]+$/.test(comarcaId)) {
+  // Older saves stored a plain list of guessed ids; convert to events
+  const events = Array.isArray(saved.events)
+    ? saved.events
+    : Array.isArray(saved.guessed_ids)
+      ? saved.guessed_ids.map(id => ({ t: "g", id: id }))
+      : null;
+  if (!events) {
+    return;
+  }
+  for (const event of events) {
+    if (!game_state.game_running) {
       break;
     }
-    const comarca = svgElement.querySelector(`g#${comarcaId}`);
-    if (comarca) {
-      applyGuess(comarca, false);
+    if (event.t === "h") {
+      applyHint(false);
+    } else if (event.t === "g" && /^[a-z_]+$/.test(event.id)) {
+      const comarca = svgElement.querySelector(`g#${event.id}`);
+      if (comarca) {
+        applyGuess(comarca, false);
+      }
     }
   }
 }
@@ -210,10 +226,12 @@ document.getElementById("btn-guess").addEventListener("click", () => {
 
 function applyGuess(comarca, save = true) {
   // Reveal comarca and apply color based on correctness
+  clearHintMarks(comarca);
   comarca.style.display = "inline";
   const guessIcon = checkGuess(comarca.id);
   game_state.guessed_ids.push(comarca.id);
   game_state.guesses_status.push(guessIcon);
+  game_state.events.push({ t: "g", id: comarca.id });
   updateGuessHistory(comarca.getAttribute("data-comarca"), guessIcon);
   if (save) {
     saveProgress();
@@ -231,7 +249,119 @@ function applyGuess(comarca, save = true) {
     return;
   }
 
+  checkOutOfGuesses();
   updateGuessButton();
+}
+
+// Progressive hints (issue #17): each hint costs one guess slot.
+// Level 1 outlines the next optimal comarca, level 2 outlines every
+// comarca still on a shortest path, level 3 adds their initials.
+const maxHints = 3;
+
+function applyHint(save = true) {
+  if (!game_state.game_running || game_state.hints_used >= maxHints) {
+    return;
+  }
+  const svgElement = document.querySelector("svg");
+  game_state.hints_used++;
+
+  let description;
+  if (game_state.hints_used === 1) {
+    outlineComarca(svgElement.querySelector(`g#${game_state.shortests_paths[0][0]}`));
+    description = "Next comarca outlined";
+  } else if (game_state.hints_used === 2) {
+    remainingPathIds().forEach(id => outlineComarca(svgElement.querySelector(`g#${id}`)));
+    description = "All path comarques outlined";
+  } else {
+    remainingPathIds().forEach(id => {
+      const group = svgElement.querySelector(`g#${id}`);
+      outlineComarca(group);
+      addInitials(group);
+    });
+    description = "Path initials shown";
+  }
+
+  game_state.guesses_status.push("💡");
+  game_state.events.push({ t: "h" });
+  updateGuessHistory(description, "💡");
+  if (save) {
+    saveProgress();
+  }
+
+  updateHintButton();
+  checkOutOfGuesses();
+  updateGuessButton();
+}
+
+// Every comarca still left on any shortest path (guessed ones are
+// spliced out by checkGuess)
+function remainingPathIds() {
+  return [...new Set(game_state.shortests_paths.flat())];
+}
+
+function outlineComarca(group) {
+  const shape = group.querySelector("polygon") || group.querySelector("path");
+  if (shape && !shape.dataset.hintOutlined) {
+    // The original fill lives in the shape's inline style attribute, so
+    // remember it to restore when the comarca is guessed
+    shape.dataset.hintOutlined = "true";
+    shape.dataset.prevFill = shape.style.fill;
+    shape.style.fill = "none";
+    shape.style.strokeDasharray = "3 2";
+  }
+  group.style.display = "inline";
+}
+
+function addInitials(group) {
+  if (group.querySelector("text.hint-initials")) {
+    return;
+  }
+  const shape = group.querySelector("polygon") || group.querySelector("path");
+  const bbox = shape.getBBox();
+  const initials = group.getAttribute("data-comarca")
+    .split(/\s+/)
+    .map(word => word[0].toUpperCase())
+    .join("");
+  const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
+  text.setAttribute("x", bbox.x + bbox.width / 2);
+  text.setAttribute("y", bbox.y + bbox.height / 2);
+  text.setAttribute("class", "hint-initials");
+  text.textContent = initials;
+  group.appendChild(text);
+}
+
+// Undo hint styling once the comarca is actually guessed
+function clearHintMarks(comarca) {
+  const shape = comarca.querySelector("polygon") || comarca.querySelector("path");
+  if (shape && shape.dataset.hintOutlined) {
+    shape.style.fill = shape.dataset.prevFill;
+    shape.style.strokeDasharray = "";
+    delete shape.dataset.hintOutlined;
+    delete shape.dataset.prevFill;
+  }
+  const initials = comarca.querySelector("text.hint-initials");
+  if (initials) {
+    initials.remove();
+  }
+}
+
+function usedGuesses() {
+  return game_state.guessed_ids.length + game_state.hints_used;
+}
+
+function checkOutOfGuesses() {
+  if (game_state.game_running && usedGuesses() >= game_state.max_guesses) {
+    endGame("Out of guesses! Try again tomorrow.", "red");
+  }
+}
+
+document.getElementById("btn-hint").addEventListener("click", () => applyHint());
+
+function updateHintButton() {
+  const button = document.getElementById("btn-hint");
+  const hintsLeft = maxHints - game_state.hints_used;
+  button.textContent = `💡 (${hintsLeft})`;
+  button.disabled = hintsLeft === 0 || !game_state.game_running;
 }
 
 function showFeedback(message, color) {
@@ -245,13 +375,14 @@ function endGame(message, color) {
   showFeedback(message, color);
   document.getElementById("comarques-input").disabled = true;
   document.getElementById("btn-guess").disabled = true;
+  document.getElementById("btn-hint").disabled = true;
   document.getElementById("btn-share").hidden = false;
 }
 
 function buildShareText() {
   const gameNumber = game_state.day + 1;
   const won = game_state.shortests_paths.some(path => path.length === 0);
-  const extraGuesses = game_state.guessed_ids.length - game_state.shortest_path_length;
+  const extraGuesses = usedGuesses() - game_state.shortest_path_length;
   const score = won ? `+${extraGuesses}` : "X";
   return `#viatgle #${gameNumber} ${score}\n${game_state.guesses_status.join("")}\n${GAME_URL}`;
 }
@@ -274,7 +405,7 @@ function updateGuessButton() {
   if (!game_state.game_running) {
     return;
   }
-  document.getElementById("btn-guess").textContent = `Guess (${game_state.guessed_ids.length + 1}/${game_state.max_guesses})`;
+  document.getElementById("btn-guess").textContent = `Guess (${usedGuesses() + 1}/${game_state.max_guesses})`;
 }
 
 function getComarcaName(comarcaId, svgElement) {

--- a/src/script.js
+++ b/src/script.js
@@ -85,6 +85,7 @@ async function initializeGame() {
   });
 
   populateDropdown(svgElement);
+  initPanZoom(svgElement, document.getElementById("map-container"));
   document.getElementById("start-comarca").textContent = getComarcaName(game_state.start, svgElement);
   document.getElementById("end-comarca").textContent = getComarcaName(game_state.end, svgElement);
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -92,6 +92,28 @@ button.guess-button {
   margin-top: 10px;
 }
 
+button.hint-button {
+  margin-left: 10px;
+  padding: 10px 10px;
+  cursor: pointer;
+}
+
+button.hint-button:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+/* Initials drawn on outlined comarques by the third hint */
+.hint-initials {
+  font-family: Arial, sans-serif;
+  font-size: 10px;
+  font-weight: bold;
+  fill: #555;
+  text-anchor: middle;
+  dominant-baseline: middle;
+  pointer-events: none;
+}
+
 button.share-button {
   padding: 10px 20px;
   margin-bottom: 10px;

--- a/src/styles.css
+++ b/src/styles.css
@@ -40,6 +40,33 @@ h1 {
   position: relative;
   background-color: white;
   margin-bottom: 10px;
+  /* Let the pan/pinch pointer handlers own all touch gestures on the map */
+  touch-action: none;
+  user-select: none;
+}
+
+.zoom-controls {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.zoom-controls button {
+  width: 34px;
+  height: 34px;
+  font-size: 1.1rem;
+  line-height: 1;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: #ffffffcc;
+  cursor: pointer;
+}
+
+.zoom-controls button:hover {
+  background-color: #f0f0f0;
 }
 
 /* Comarques start hidden so the full map is never visible while loading;


### PR DESCRIPTION
Same situation as #25: the stacked PRs #26 and #27 merged into their base branches (`sprint-1-stability-fixes` and `sprint-3-zoom`) instead of `main`, because the head branches weren't deleted on merge so GitHub never retargeted them. `main` currently stops at Sprint 2 — the live site has no zoom or hints.

This PR contains exactly the already-reviewed zoom (#26) and hints (#27) commits. No new changes.

**To avoid this a third time:** Settings → General → check "Automatically delete head branches". From then on, merging the bottom PR of a stack retargets the ones above it to `main` automatically. I'll also base future PRs directly on `main` now that the stack has collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)