### PR TITLE
Sprint 4: i18n — Catalan, Spanish, English (#13)

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,88 @@
+// Minimal i18n: translations inline (no extra request), Catalan default.
+// The language is picked from localStorage ("viatgle-lang"), then the
+// browser language, then Catalan.
+const TRANSLATIONS = {
+  ca: {
+    title: "Avui m'agradaria anar {de_start} a {end}.",
+    input_placeholder: "Escriu una comarca...",
+    guess_button: "Endevina ({n}/{max})",
+    hint_button_title: "Fes servir una pista (costa una tirada)",
+    share_button: "📋 Comparteix el resultat",
+    invalid_comarca: "Aquesta comarca no existeix!",
+    already_guessed: "Ja l'has dita!",
+    won: "Has guanyat! Enhorabona!",
+    lost: "Has perdut! Torna-ho a provar demà.",
+    out_of_guesses: "T'has quedat sense tirades! Torna demà.",
+    copied: "Resultat copiat al porta-retalls!",
+    hint_next_outline: "Contorn de la comarca següent",
+    hint_all_outlines: "Contorn de les comarques del camí",
+    hint_initials: "Inicials de les comarques del camí",
+    zoom_in: "Amplia",
+    zoom_out: "Redueix",
+    zoom_reset: "Restableix el zoom"
+  },
+  es: {
+    title: "Hoy me gustaría ir de {start} a {end}.",
+    input_placeholder: "Escribe una comarca...",
+    guess_button: "Adivina ({n}/{max})",
+    hint_button_title: "Usa una pista (cuesta un intento)",
+    share_button: "📋 Comparte el resultado",
+    invalid_comarca: "¡Esta comarca no existe!",
+    already_guessed: "¡Ya la has dicho!",
+    won: "¡Has ganado! ¡Enhorabuena!",
+    lost: "¡Has perdido! Vuelve a intentarlo mañana.",
+    out_of_guesses: "¡Te has quedado sin intentos! Vuelve mañana.",
+    copied: "¡Resultado copiado al portapapeles!",
+    hint_next_outline: "Contorno de la siguiente comarca",
+    hint_all_outlines: "Contorno de las comarcas del camino",
+    hint_initials: "Iniciales de las comarcas del camino",
+    zoom_in: "Ampliar",
+    zoom_out: "Reducir",
+    zoom_reset: "Restablecer el zoom"
+  },
+  en: {
+    title: "Today I'd like to go from {start} to {end}.",
+    input_placeholder: "Enter a comarca...",
+    guess_button: "Guess ({n}/{max})",
+    hint_button_title: "Use a hint (costs one guess)",
+    share_button: "📋 Share result",
+    invalid_comarca: "Invalid comarca!",
+    already_guessed: "Already guessed!",
+    won: "You won! Congratulations!",
+    lost: "You lost! Try again tomorrow.",
+    out_of_guesses: "Out of guesses! Try again tomorrow.",
+    copied: "Result copied to clipboard!",
+    hint_next_outline: "Next comarca outlined",
+    hint_all_outlines: "Path comarques outlined",
+    hint_initials: "Path initials shown",
+    zoom_in: "Zoom in",
+    zoom_out: "Zoom out",
+    zoom_reset: "Reset zoom"
+  }
+};
+
+const LANG_KEY = "viatgle-lang";
+
+function detectLanguage() {
+  const saved = localStorage.getItem(LANG_KEY);
+  if (saved && TRANSLATIONS[saved]) {
+    return saved;
+  }
+  const browserLang = (navigator.language || "ca").slice(0, 2).toLowerCase();
+  return TRANSLATIONS[browserLang] ? browserLang : "ca";
+}
+
+const currentLang = detectLanguage();
+
+function t(key, params = {}) {
+  let text = TRANSLATIONS[currentLang][key] || TRANSLATIONS.ca[key] || key;
+  for (const [name, value] of Object.entries(params)) {
+    text = text.replaceAll(`{${name}}`, value);
+  }
+  return text;
+}
+
+// Catalan elides "de" before a vowel or h: "d'Osona", "de Garrotxa"
+function caDeParticle(name) {
+  return /^[aeiouhàèéíòóú]/i.test(name) ? "d'" : "de ";
+}

--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,12 @@
 </head>
 <body>
   <div class="game-container">
-    <h1 id="game-title">Today I'd like to go from <span id="start-comarca"></span> to <span id="end-comarca"></span>.</h1>
+    <select id="lang-select" class="lang-select" aria-label="Idioma / Language">
+      <option value="ca">Català</option>
+      <option value="es">Castellano</option>
+      <option value="en">English</option>
+    </select>
+    <h1 id="game-title"></h1>
     
     <!-- Map -->
     <div id="map-container" class="map-container">
@@ -35,6 +40,7 @@
     <div id='tooltip'></div>   
   </div>
 
+  <script src="i18n.js"></script>
   <script src="panzoom.js"></script>
   <script src="script.js"></script>
 </body>

--- a/src/panzoom.js
+++ b/src/panzoom.js
@@ -116,9 +116,9 @@ function initPanZoom(svgElement, container) {
   const controls = document.createElement("div");
   controls.className = "zoom-controls";
   [
-    ["+", "Zoom in", () => zoomAtCenter(1 / WHEEL_STEP ** 2)],
-    ["−", "Zoom out", () => zoomAtCenter(WHEEL_STEP ** 2)],
-    ["⛶", "Reset zoom", reset],
+    ["+", t("zoom_in"), () => zoomAtCenter(1 / WHEEL_STEP ** 2)],
+    ["−", t("zoom_out"), () => zoomAtCenter(WHEEL_STEP ** 2)],
+    ["⛶", t("zoom_reset"), reset],
   ].forEach(([label, title, onClick]) => {
     const button = document.createElement("button");
     button.type = "button";

--- a/src/script.js
+++ b/src/script.js
@@ -6,6 +6,7 @@ const STORAGE_KEY = "viatgle-progress";
 const GAME_URL = "https://victormico.github.io/viatgle";
 
 document.addEventListener("DOMContentLoaded", () => {
+  applyTranslations();
   // Load the map
   fetch("master.svg")
     .then(response => response.text())
@@ -88,8 +89,7 @@ async function initializeGame() {
 
   populateDropdown(svgElement);
   initPanZoom(svgElement, document.getElementById("map-container"));
-  document.getElementById("start-comarca").textContent = getComarcaName(game_state.start, svgElement);
-  document.getElementById("end-comarca").textContent = getComarcaName(game_state.end, svgElement);
+  setGameTitle(getComarcaName(game_state.start, svgElement), getComarcaName(game_state.end, svgElement));
 
   restoreProgress(svgElement);
   updateGuessButton();
@@ -209,12 +209,12 @@ document.getElementById("btn-guess").addEventListener("click", () => {
   );
 
   if (!comarca) {
-      showFeedback("Invalid comarca!", "red");
+      showFeedback(t("invalid_comarca"), "red");
       return;
   }
 
   if (game_state.guessed_ids.includes(comarca.id)) {
-      showFeedback("Already guessed!", "orange");
+      showFeedback(t("already_guessed"), "orange");
       return;
   }
 
@@ -241,11 +241,11 @@ function applyGuess(comarca, save = true) {
   if (guessIcon === game_state.guesses_icons.bad) {
       game_state.incorrect_guesses++;
       if (game_state.incorrect_guesses >= maxIncorrectGuesses) {
-          endGame("You lost! Try again tomorrow.", "red");
+          endGame(t("lost"), "red");
           return;
       }
   } else if (game_state.shortests_paths.some(path => path.length === 0)) {
-    endGame("You won! Congratulations!", "green");
+    endGame(t("won"), "green");
     return;
   }
 
@@ -268,17 +268,17 @@ function applyHint(save = true) {
   let description;
   if (game_state.hints_used === 1) {
     outlineComarca(svgElement.querySelector(`g#${game_state.shortests_paths[0][0]}`));
-    description = "Next comarca outlined";
+    description = t("hint_next_outline");
   } else if (game_state.hints_used === 2) {
     remainingPathIds().forEach(id => outlineComarca(svgElement.querySelector(`g#${id}`)));
-    description = "All path comarques outlined";
+    description = t("hint_all_outlines");
   } else {
     remainingPathIds().forEach(id => {
       const group = svgElement.querySelector(`g#${id}`);
       outlineComarca(group);
       addInitials(group);
     });
-    description = "Path initials shown";
+    description = t("hint_initials");
   }
 
   game_state.guesses_status.push("💡");
@@ -351,7 +351,7 @@ function usedGuesses() {
 
 function checkOutOfGuesses() {
   if (game_state.game_running && usedGuesses() >= game_state.max_guesses) {
-    endGame("Out of guesses! Try again tomorrow.", "red");
+    endGame(t("out_of_guesses"), "red");
   }
 }
 
@@ -362,6 +362,32 @@ function updateHintButton() {
   const hintsLeft = maxHints - game_state.hints_used;
   button.textContent = `💡 (${hintsLeft})`;
   button.disabled = hintsLeft === 0 || !game_state.game_running;
+}
+
+function applyTranslations() {
+  document.documentElement.lang = currentLang;
+  document.getElementById("comarques-input").placeholder = t("input_placeholder");
+  document.getElementById("btn-hint").title = t("hint_button_title");
+  document.getElementById("btn-share").textContent = t("share_button");
+
+  const langSelect = document.getElementById("lang-select");
+  langSelect.value = currentLang;
+  langSelect.addEventListener("change", () => {
+    localStorage.setItem(LANG_KEY, langSelect.value);
+    location.reload(); // game progress survives via viatgle-progress
+  });
+}
+
+// The title keeps the colored start/end spans, so build it from the
+// translated template with placeholders swapped for the spans.
+// {de_start} (Catalan) resolves the elided particle first: d'Osona / de Garrotxa.
+function setGameTitle(startName, endName) {
+  document.getElementById("game-title").innerHTML = t("title")
+    .replace("{de_start}", caDeParticle(startName) + "{start}")
+    .replace("{start}", '<span id="start-comarca"></span>')
+    .replace("{end}", '<span id="end-comarca"></span>');
+  document.getElementById("start-comarca").textContent = startName;
+  document.getElementById("end-comarca").textContent = endName;
 }
 
 function showFeedback(message, color) {
@@ -394,7 +420,7 @@ document.getElementById("btn-share").addEventListener("click", async () => {
       await navigator.share({ text });
     } else {
       await navigator.clipboard.writeText(text);
-      showFeedback("Result copied to clipboard!", "green");
+      showFeedback(t("copied"), "green");
     }
   } catch (err) {
     // Share sheet dismissed or clipboard unavailable; nothing to do
@@ -405,7 +431,7 @@ function updateGuessButton() {
   if (!game_state.game_running) {
     return;
   }
-  document.getElementById("btn-guess").textContent = `Guess (${usedGuesses() + 1}/${game_state.max_guesses})`;
+  document.getElementById("btn-guess").textContent = t("guess_button", { n: usedGuesses() + 1, max: game_state.max_guesses });
 }
 
 function getComarcaName(comarcaId, svgElement) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -12,9 +12,21 @@ body {
 
 .game-container {
   max-width: 450px;
-  margin: 20px auto;
+  margin: 0 auto 20px;
+  padding-top: 44px;
   text-align: center;
-  
+  position: relative;
+}
+
+.lang-select {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  padding: 4px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: white;
+  font-size: 0.85rem;
 }
 
 #start-comarca {


### PR DESCRIPTION
Stacked on #28 (base `sprint-3-zoom` so the diff shows only the i18n work). **Merge #28 first**, and tick "delete branch" so this one retargets to `main` automatically.

## What

- **`src/i18n.js` (new)** — all UI strings inline (no extra network request), `t(key, params)` helper, and language detection: `localStorage` override → browser language → **Catalan default** (it's a game about the Catalan Countries).
- **Language selector** top-right (Català / Castellano / English). Changing it saves the choice and reloads — game progress survives through the existing persistence, verified.
- **Title templating** — the h1 is built from a translated template that keeps the colored start/end spans. Catalan gets proper elision: *"anar **d'**Alt Camp"* vs *"anar **de** Cerdanya"*.
- Every string translated: feedback messages, guess/share buttons, input placeholder, hint history chips, hint tooltip, zoom button titles. `<html lang>` is set to the active language.
- Share text stays language-neutral (hashtag + emoji), as it's the viral artifact.

## Verification (driven in Chrome, browser language ca-ES)

- Fresh load auto-detects Catalan: "Avui m'agradaria anar de Cerdanya a Alcalatén.", "Escriu una comarca...", "Endevina (1/11)", Catalan zoom tooltips.
- Elision: rendering a vowel-initial start comarca produces "anar d'Alt Camp a Osona."
- Switched to Castellano → full Spanish UI; invalid guess shows "¡Esta comarca no existe!".
- Made a guess in Spanish, switched to English → guess history, map reveal, and counter all survive the switch; UI fully English.
- Layout: selector pinned top-right of the viewport; container padded so the title never collides with it (first attempt overlapped — fixed).

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)