### PR TITLE
Phase 2a: end-game modal with stats, streaks & confetti

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -19,7 +19,14 @@ const TRANSLATIONS = {
     hint_initials: "Inicials de les comarques del camí",
     zoom_in: "Amplia",
     zoom_out: "Redueix",
-    zoom_reset: "Restableix el zoom"
+    zoom_reset: "Restableix el zoom",
+    stats_title: "Estadístiques",
+    stat_played: "Jugades",
+    stat_win_pct: "% victòries",
+    stat_streak: "Ratxa",
+    stat_max_streak: "Ratxa màx.",
+    dist_title: "Tirades de més",
+    next_game: "Següent viatgle en"
   },
   es: {
     title: "Hoy me gustaría ir de {start} a {end}.",
@@ -38,7 +45,14 @@ const TRANSLATIONS = {
     hint_initials: "Iniciales de las comarcas del camino",
     zoom_in: "Ampliar",
     zoom_out: "Reducir",
-    zoom_reset: "Restablecer el zoom"
+    zoom_reset: "Restablecer el zoom",
+    stats_title: "Estadísticas",
+    stat_played: "Jugadas",
+    stat_win_pct: "% victorias",
+    stat_streak: "Racha",
+    stat_max_streak: "Racha máx.",
+    dist_title: "Intentos de más",
+    next_game: "Siguiente viatgle en"
   },
   en: {
     title: "Today I'd like to go from {start} to {end}.",
@@ -57,7 +71,14 @@ const TRANSLATIONS = {
     hint_initials: "Path initials shown",
     zoom_in: "Zoom in",
     zoom_out: "Zoom out",
-    zoom_reset: "Reset zoom"
+    zoom_reset: "Reset zoom",
+    stats_title: "Statistics",
+    stat_played: "Played",
+    stat_win_pct: "Win %",
+    stat_streak: "Streak",
+    stat_max_streak: "Max streak",
+    dist_title: "Extra guesses",
+    next_game: "Next viatgle in"
   }
 };
 

--- a/src/index.html
+++ b/src/index.html
@@ -26,18 +26,40 @@
       <input id="comarques-input" class="form-control input-lg dropdown-toggle" placeholder="Enter a comarca..." aria-describedby="btn-guess" data-bs-toggle="dropdown">
       <button id="btn-guess" class="btn btn-outline-success btn-lg guess-button" type="button">Guess</button>
       <button id="btn-hint" class="hint-button" type="button" title="Use a hint (costs one guess)">💡 (3)</button>
+      <button id="btn-stats" class="stats-button" type="button">📊</button>
 
 
     </div>
 
     <!-- Feedback -->
     <p id="feedback" class="feedback-message"></p>
-    <!-- Share result (shown when the game ends) -->
-    <button id="btn-share" class="share-button" type="button" hidden>📋 Share result</button>
     <!-- Guess History -->
     <div id="guess-history" class="guess-history"></div> 
     <!-- Tooltip -->
-    <div id='tooltip'></div>   
+    <div id='tooltip'></div>
+
+    <!-- End-game / stats modal -->
+    <div id="modal-overlay" class="modal-overlay" hidden>
+      <div class="modal" role="dialog" aria-modal="true">
+        <button id="modal-close" class="modal-close" type="button" aria-label="×">×</button>
+        <h2 id="modal-title"></h2>
+        <div class="stats-grid">
+          <div class="stat"><span class="stat-value" id="stat-played"></span><span class="stat-label" id="label-played"></span></div>
+          <div class="stat"><span class="stat-value" id="stat-winpct"></span><span class="stat-label" id="label-winpct"></span></div>
+          <div class="stat"><span class="stat-value" id="stat-streak"></span><span class="stat-label" id="label-streak"></span></div>
+          <div class="stat"><span class="stat-value" id="stat-maxstreak"></span><span class="stat-label" id="label-maxstreak"></span></div>
+        </div>
+        <h3 id="dist-title" class="dist-title"></h3>
+        <div id="distribution" class="distribution"></div>
+        <div class="modal-footer">
+          <div class="countdown">
+            <span class="countdown-label" id="countdown-label"></span>
+            <span class="countdown-value" id="countdown-value"></span>
+          </div>
+          <button id="btn-share" class="share-button" type="button" hidden>📋 Share result</button>
+        </div>
+      </div>
+    </div>
   </div>
 
   <script src="i18n.js"></script>

--- a/src/script.js
+++ b/src/script.js
@@ -3,6 +3,7 @@ let game_state = {}; // Initialize game state
 
 const maxIncorrectGuesses = 5;
 const STORAGE_KEY = "viatgle-progress";
+const STATS_KEY = "viatgle-stats";
 const GAME_URL = "https://victormico.github.io/viatgle";
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -241,15 +242,15 @@ function applyGuess(comarca, save = true) {
   if (guessIcon === game_state.guesses_icons.bad) {
       game_state.incorrect_guesses++;
       if (game_state.incorrect_guesses >= maxIncorrectGuesses) {
-          endGame(t("lost"), "red");
+          endGame(t("lost"), "red", save);
           return;
       }
   } else if (game_state.shortests_paths.some(path => path.length === 0)) {
-    endGame(t("won"), "green");
+    endGame(t("won"), "green", save);
     return;
   }
 
-  checkOutOfGuesses();
+  checkOutOfGuesses(save);
   updateGuessButton();
 }
 
@@ -289,7 +290,7 @@ function applyHint(save = true) {
   }
 
   updateHintButton();
-  checkOutOfGuesses();
+  checkOutOfGuesses(save);
   updateGuessButton();
 }
 
@@ -349,9 +350,9 @@ function usedGuesses() {
   return game_state.guessed_ids.length + game_state.hints_used;
 }
 
-function checkOutOfGuesses() {
+function checkOutOfGuesses(live = true) {
   if (game_state.game_running && usedGuesses() >= game_state.max_guesses) {
-    endGame(t("out_of_guesses"), "red");
+    endGame(t("out_of_guesses"), "red", live);
   }
 }
 
@@ -368,6 +369,7 @@ function applyTranslations() {
   document.documentElement.lang = currentLang;
   document.getElementById("comarques-input").placeholder = t("input_placeholder");
   document.getElementById("btn-hint").title = t("hint_button_title");
+  document.getElementById("btn-stats").title = t("stats_title");
   document.getElementById("btn-share").textContent = t("share_button");
 
   const langSelect = document.getElementById("lang-select");
@@ -396,14 +398,154 @@ function showFeedback(message, color) {
   feedback.style.color = color;
 }
 
-function endGame(message, color) {
+function endGame(message, color, live = true) {
   game_state.game_running = false;
+  game_state.end_message = message;
   showFeedback(message, color);
   document.getElementById("comarques-input").disabled = true;
   document.getElementById("btn-guess").disabled = true;
   document.getElementById("btn-hint").disabled = true;
-  document.getElementById("btn-share").hidden = false;
+
+  const won = game_state.shortests_paths.some(path => path.length === 0);
+  recordGameEnd(won);
+  if (live && won) {
+    launchConfetti();
+  }
+  setTimeout(openStatsModal, 900);
 }
+
+// ---- Stats, streaks and the end-game modal ----
+
+function loadStats() {
+  let stats = null;
+  try {
+    stats = JSON.parse(localStorage.getItem(STATS_KEY));
+  } catch (err) {
+    // fall through to defaults
+  }
+  return Object.assign({
+    played: 0,
+    wins: 0,
+    current_streak: 0,
+    max_streak: 0,
+    last_recorded_day: null,
+    last_won_day: null,
+    distribution: {}
+  }, stats || {});
+}
+
+// Idempotent per day: replaying a finished game on reload must not
+// count it twice
+function recordGameEnd(won) {
+  const stats = loadStats();
+  if (stats.last_recorded_day === game_state.day) {
+    return stats;
+  }
+  stats.last_recorded_day = game_state.day;
+  stats.played++;
+  if (won) {
+    stats.wins++;
+    stats.current_streak = stats.last_won_day === game_state.day - 1 ? stats.current_streak + 1 : 1;
+    stats.max_streak = Math.max(stats.max_streak, stats.current_streak);
+    stats.last_won_day = game_state.day;
+    const bucket = String(usedGuesses() - game_state.shortest_path_length);
+    stats.distribution[bucket] = (stats.distribution[bucket] || 0) + 1;
+  } else {
+    stats.current_streak = 0;
+    stats.distribution.X = (stats.distribution.X || 0) + 1;
+  }
+  try {
+    localStorage.setItem(STATS_KEY, JSON.stringify(stats));
+  } catch (err) {
+    // Storage unavailable; stats just won't persist
+  }
+  return stats;
+}
+
+let countdownInterval = null;
+
+function openStatsModal() {
+  const stats = loadStats();
+  document.getElementById("modal-title").textContent =
+    game_state.game_running ? t("stats_title") : game_state.end_message;
+
+  document.getElementById("stat-played").textContent = stats.played;
+  document.getElementById("stat-winpct").textContent =
+    stats.played ? Math.round((stats.wins / stats.played) * 100) + "%" : "-";
+  document.getElementById("stat-streak").textContent = stats.current_streak;
+  document.getElementById("stat-maxstreak").textContent = stats.max_streak;
+  document.getElementById("label-played").textContent = t("stat_played");
+  document.getElementById("label-winpct").textContent = t("stat_win_pct");
+  document.getElementById("label-streak").textContent = t("stat_streak");
+  document.getElementById("label-maxstreak").textContent = t("stat_max_streak");
+  document.getElementById("dist-title").textContent = t("dist_title");
+  renderDistribution(stats);
+
+  document.getElementById("btn-share").hidden = game_state.game_running;
+  startCountdown();
+  document.getElementById("modal-overlay").hidden = false;
+}
+
+function closeStatsModal() {
+  document.getElementById("modal-overlay").hidden = true;
+  clearInterval(countdownInterval);
+  countdownInterval = null;
+}
+
+function renderDistribution(stats) {
+  const buckets = ["0", "1", "2", "3", "4", "5", "X"];
+  const maxCount = Math.max(1, ...buckets.map(b => stats.distribution[b] || 0));
+  document.getElementById("distribution").innerHTML = buckets.map(bucket => {
+    const count = stats.distribution[bucket] || 0;
+    const width = Math.max(8, Math.round((count / maxCount) * 100));
+    const label = bucket === "X" ? "X" : "+" + bucket;
+    return `<div class="dist-row"><span class="dist-label">${label}</span>` +
+      `<div class="dist-bar${count ? "" : " dist-bar-empty"}" style="width:${width}%">${count}</div></div>`;
+  }).join("");
+}
+
+function startCountdown() {
+  document.getElementById("countdown-label").textContent = t("next_game");
+  const value = document.getElementById("countdown-value");
+  function tick() {
+    const now = new Date();
+    const nextMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+    const ms = nextMidnight - now;
+    const h = String(Math.floor(ms / 3600000)).padStart(2, "0");
+    const m = String(Math.floor(ms / 60000) % 60).padStart(2, "0");
+    const s = String(Math.floor(ms / 1000) % 60).padStart(2, "0");
+    value.textContent = `${h}:${m}:${s}`;
+  }
+  tick();
+  clearInterval(countdownInterval);
+  countdownInterval = setInterval(tick, 1000);
+}
+
+function launchConfetti() {
+  const colors = [
+    getComputedStyle(document.documentElement).getPropertyValue("--start-color"),
+    getComputedStyle(document.documentElement).getPropertyValue("--end-color"),
+    "#4caf50", "#ffc107", "#03a9f4"
+  ];
+  for (let i = 0; i < 90; i++) {
+    const piece = document.createElement("div");
+    piece.className = "confetti";
+    piece.style.left = Math.random() * 100 + "vw";
+    piece.style.backgroundColor = colors[i % colors.length];
+    piece.style.animationDelay = Math.random() * 0.8 + "s";
+    piece.style.animationDuration = 2 + Math.random() * 2 + "s";
+    document.body.appendChild(piece);
+  }
+  setTimeout(() => document.querySelectorAll(".confetti").forEach(p => p.remove()), 5000);
+}
+
+document.getElementById("btn-stats").addEventListener("click", openStatsModal);
+document.getElementById("modal-close").addEventListener("click", closeStatsModal);
+document.getElementById("modal-overlay").addEventListener("click", (e) => {
+  if (e.target.id === "modal-overlay") {
+    closeStatsModal();
+  }
+});
 
 function buildShareText() {
   const gameNumber = game_state.day + 1;

--- a/src/styles.css
+++ b/src/styles.css
@@ -128,9 +128,169 @@ button.hint-button:disabled {
 
 button.share-button {
   padding: 10px 20px;
-  margin-bottom: 10px;
   font-size: 1rem;
   cursor: pointer;
+}
+
+button.stats-button {
+  margin-left: 10px;
+  padding: 10px 10px;
+  cursor: pointer;
+}
+
+/* End-game / stats modal */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+/* display:flex above would override the hidden attribute's display:none */
+.modal-overlay[hidden] {
+  display: none;
+}
+
+.modal {
+  position: relative;
+  background-color: white;
+  border-radius: 12px;
+  padding: 24px;
+  width: min(90vw, 340px);
+  max-height: 85vh;
+  overflow-y: auto;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+  text-align: center;
+}
+
+.modal h2 {
+  margin: 0 30px 16px;
+  font-size: 1.2rem;
+}
+
+.modal-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: none;
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #666;
+}
+
+.stats-grid {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.stat {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.stat-value {
+  font-size: 1.6rem;
+  font-weight: bold;
+}
+
+.stat-label {
+  font-size: 0.7rem;
+  color: #666;
+}
+
+.dist-title {
+  font-size: 0.9rem;
+  margin: 0 0 8px;
+}
+
+.distribution {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 16px;
+}
+
+.dist-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.dist-label {
+  width: 24px;
+  font-size: 0.8rem;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.dist-bar {
+  background-color: #4caf50;
+  color: white;
+  font-size: 0.75rem;
+  font-weight: bold;
+  padding: 2px 6px;
+  border-radius: 3px;
+  text-align: right;
+  min-width: 14px;
+  box-sizing: border-box;
+}
+
+.dist-bar-empty {
+  background-color: #ccc;
+}
+
+.modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-top: 1px solid #eee;
+  padding-top: 16px;
+}
+
+.countdown {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+}
+
+.countdown-label {
+  font-size: 0.7rem;
+  color: #666;
+}
+
+.countdown-value {
+  font-size: 1.3rem;
+  font-weight: bold;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Win celebration */
+.confetti {
+  position: fixed;
+  top: -12px;
+  width: 8px;
+  height: 14px;
+  z-index: 200;
+  pointer-events: none;
+  animation: confetti-fall linear forwards;
+}
+
+@keyframes confetti-fall {
+  to {
+    transform: translateY(110vh) rotate(720deg);
+    opacity: 0.7;
+  }
 }
 
 .guess-history {


### PR DESCRIPTION
First Phase 2 component. Stacked on #30 (base `sprint-3-zoom`) — **merge #30 first** and delete branches on merge.

## What

The daily-game ritual layer, built on the persistence from Sprint 2:

- **Stats & streaks** (`viatgle-stats` in localStorage): games played, win %, current and max streak, and a Wordle-style distribution of *extra guesses* (+0 = perfect route … +5, X = loss). Hints count as extra guesses, so the distribution reflects assisted wins honestly.
  - Recording is **idempotent per day** (`last_recorded_day`), so replaying a finished game on reload never double-counts.
  - Streaks continue only across **consecutive won days** (`last_won_day === day - 1`).
- **End-game modal**: opens ~1s after the game ends (and any time via a new 📊 button): result title, four stat tiles, distribution bars, a live countdown to the next puzzle (local midnight), and the share button — which moved into the modal, hidden while a game is running.
- **Confetti** on wins: ~90 CSS-animated pieces in the game's palette, hand-rolled (no library). Replayed wins after a reload don't re-celebrate (the `live` flag threads through the guess/replay path).
- All new strings translated in ca/es/en.

## Verification (played in Chrome, Catalan UI)

- 📊 mid-game → modal with zeroed stats, "-" win %, ticking countdown, share hidden. Closed via × and via overlay click.
- Won the puzzle in 6/6 optimal guesses → confetti rains, modal auto-opens: "Has guanyat! Enhorabona!", 1 played / 100% / streak 1 / max 1, distribution +0 = 1, share visible.
- Share from the modal → "Resultat copiat al porta-retalls!" with the correct `#viatgle #579 +0` text.
- 🔍 Reload after the win → modal reopens, stats **unchanged** (played still 1) — the idempotency held.
- 🔍 Simulated "yesterday was a win" (`last_recorded_day/last_won_day = 577`) → reload records today again and the streak climbs to 2, max 2.
- 🔍 Found & fixed while verifying: the modal rendered visible on first load because `.modal-overlay { display:flex }` overrides the `hidden` attribute — added a `[hidden] { display:none }` rule.

Known nit (deliberate for now): the "copied" confirmation renders in the feedback line behind the overlay; moving it inside the modal is a one-liner I'd fold into the next Phase 2 PR (GuessBar/JourneyTracker) which reworks that area anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)