### PR TITLE
Phase 2c: keyboard-friendly GuessBar

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -21,14 +21,14 @@
     </div>
 
     <!-- Input for guesses -->
-    <div class="input-group mb-3 ui-padding autocomplete-drop-down dropup dropdown">
+    <div class="guess-bar">
       <div class="dropdown-menu" id="autocomplete-list"></div>
-      <input id="comarques-input" class="form-control input-lg dropdown-toggle" placeholder="Enter a comarca..." aria-describedby="btn-guess" data-bs-toggle="dropdown">
-      <button id="btn-guess" class="btn btn-outline-success btn-lg guess-button" type="button">Guess</button>
+      <input id="comarques-input" placeholder="Enter a comarca..." autocomplete="off">
+      <button id="btn-guess" class="guess-button" type="button">Guess</button>
+    </div>
+    <div class="toolbar">
       <button id="btn-hint" class="hint-button" type="button" title="Use a hint (costs one guess)">💡 (3)</button>
       <button id="btn-stats" class="stats-button" type="button">📊</button>
-
-
     </div>
 
     <!-- Feedback -->
@@ -58,6 +58,7 @@
           </div>
           <button id="btn-share" class="share-button" type="button" hidden>📋 Share result</button>
         </div>
+        <p id="modal-feedback" class="modal-feedback"></p>
       </div>
     </div>
   </div>

--- a/src/script.js
+++ b/src/script.js
@@ -147,33 +147,74 @@ function restoreProgress(svgElement) {
   }
 }
 
+// Accent-insensitive comparison: "emporda" must match "Empordà"
+function normalizeText(text) {
+  return text.toLowerCase().normalize("NFD").replace(/[̀-ͯ]/g, "");
+}
+
+const MAX_SUGGESTIONS = 8;
+
 function populateDropdown(svgElement) {
   const dropdown = document.getElementById("autocomplete-list");
+  const input = document.getElementById("comarques-input");
   const comarques = Array.from(svgElement.querySelectorAll("g")).map(group => ({
     id: group.id,
     name: group.getAttribute("data-comarca"),
+    normalized: normalizeText(group.getAttribute("data-comarca")),
   }));
+  let activeIndex = -1;
 
-  const input = document.getElementById("comarques-input");
-  input.addEventListener("input", () => {
-    const query = input.value.trim().toLowerCase();
+  function renderSuggestions() {
+    const query = normalizeText(input.value.trim());
+    activeIndex = -1;
     if (!query) {
       dropdown.innerHTML = "";
       return;
     }
-    const suggestions = comarques
-      .filter(c => c.name.toLowerCase().includes(query))
+    dropdown.innerHTML = comarques
+      .filter(c => c.normalized.includes(query))
+      .slice(0, MAX_SUGGESTIONS)
       .map(c => `<button type="button" class="dropdown-item" data-id="${c.id}">${c.name}</button>`)
       .join("");
-    dropdown.innerHTML = suggestions;
+  }
 
-    // Handle suggestion click
-    dropdown.querySelectorAll(".dropdown-item").forEach(item => {
-      item.addEventListener("click", () => {
-        input.value = item.textContent;
+  input.addEventListener("input", renderSuggestions);
+
+  // One delegated listener instead of re-binding on every keystroke
+  dropdown.addEventListener("click", (e) => {
+    const item = e.target.closest(".dropdown-item");
+    if (item) {
+      input.value = item.textContent;
+      dropdown.innerHTML = "";
+      input.focus();
+    }
+  });
+
+  input.addEventListener("keydown", (e) => {
+    const items = [...dropdown.querySelectorAll(".dropdown-item")];
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      if (!items.length) {
+        return;
+      }
+      e.preventDefault();
+      activeIndex = e.key === "ArrowDown"
+        ? (activeIndex + 1) % items.length
+        : (activeIndex - 1 + items.length) % items.length;
+      items.forEach((item, i) => item.classList.toggle("active", i === activeIndex));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      // A highlighted (or single) suggestion autocompletes, then submits
+      const pick = activeIndex >= 0 ? items[activeIndex] : items.length === 1 ? items[0] : null;
+      if (pick) {
+        input.value = pick.textContent;
         dropdown.innerHTML = "";
-      });
-    });
+        activeIndex = -1;
+      }
+      submitGuess();
+    } else if (e.key === "Escape") {
+      dropdown.innerHTML = "";
+      activeIndex = -1;
+    }
   });
 }
 
@@ -204,16 +245,19 @@ mapa.addEventListener("mousemove", (e) => {
 });
 
 // Guess handling logic update
-document.getElementById("btn-guess").addEventListener("click", () => {
+function submitGuess() {
   if (!game_state.game_running) {
       return;
   }
 
   const input = document.getElementById("comarques-input");
   const guess = input.value.trim();
+  if (!guess) {
+      return;
+  }
   const svgElement = document.querySelector("svg");
   const comarca = Array.from(svgElement.querySelectorAll("g")).find(
-      g => g.getAttribute("data-comarca").toLowerCase() === guess.toLowerCase()
+      g => normalizeText(g.getAttribute("data-comarca")) === normalizeText(guess)
   );
 
   if (!comarca) {
@@ -230,7 +274,9 @@ document.getElementById("btn-guess").addEventListener("click", () => {
   input.value = "";
   document.getElementById("autocomplete-list").innerHTML = "";
   applyGuess(comarca);
-});
+}
+
+document.getElementById("btn-guess").addEventListener("click", submitGuess);
 
 function applyGuess(comarca, save = true) {
   // Reveal comarca and apply color based on correctness
@@ -580,6 +626,7 @@ function openStatsModal() {
   renderDistribution(stats);
 
   document.getElementById("btn-share").hidden = game_state.game_running;
+  document.getElementById("modal-feedback").textContent = "";
   startCountdown();
   document.getElementById("modal-overlay").hidden = false;
 }
@@ -660,6 +707,8 @@ document.getElementById("btn-share").addEventListener("click", async () => {
       await navigator.share({ text });
     } else {
       await navigator.clipboard.writeText(text);
+      // The modal overlay covers the feedback line, so confirm inside it
+      document.getElementById("modal-feedback").textContent = t("copied");
       showFeedback(t("copied"), "green");
     }
   } catch (err) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -136,16 +136,87 @@ g.revealed {
   pointer-events: none;
 }
 
-input {
-  width: 60%;
-  padding: 10px;
-  margin-top: 10px;
-  margin-bottom: 10px;
+/* Floating pill guess bar */
+.guess-bar {
+  position: relative;
+  display: flex;
+  gap: 8px;
+  margin: 0 10px;
+}
+
+.guess-bar input {
+  flex: 1;
+  min-width: 0;
+  padding: 12px 18px;
+  border: 1px solid #ccc;
+  border-radius: 24px;
+  font-size: 1rem;
+  background-color: white;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.guess-bar input:focus {
+  outline: 2px solid var(--end-color);
+  border-color: transparent;
 }
 
 button.guess-button {
-  margin-left: 10px;
-  padding: 10px 10px;
+  padding: 12px 18px;
+  border: 1px solid #2e7d32;
+  border-radius: 24px;
+  background-color: #2e7d32;
+  color: white;
+  font-size: 0.95rem;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+button.guess-button:disabled {
+  background-color: #aaa;
+  border-color: #aaa;
+  cursor: default;
+}
+
+/* Suggestions float above the guess bar */
+.dropdown-menu {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  background-color: white;
+  border-radius: 10px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.18);
+  max-height: 240px;
+  overflow-y: auto;
+  z-index: 50;
+  text-align: left;
+}
+
+.dropdown-menu:empty {
+  display: none;
+}
+
+.dropdown-item {
+  display: block;
+  width: 100%;
+  padding: 10px 16px;
+  border: none;
+  background: none;
+  font-size: 0.95rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.dropdown-item:hover,
+.dropdown-item.active {
+  background-color: #e8f0e9;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 10px;
 }
 
 .feedback-message {
@@ -154,8 +225,10 @@ button.guess-button {
 }
 
 button.hint-button {
-  margin-left: 10px;
-  padding: 10px 10px;
+  padding: 10px 14px;
+  border: 1px solid #ccc;
+  border-radius: 20px;
+  background-color: white;
   cursor: pointer;
 }
 
@@ -182,9 +255,18 @@ button.share-button {
 }
 
 button.stats-button {
-  margin-left: 10px;
-  padding: 10px 10px;
+  padding: 10px 14px;
+  border: 1px solid #ccc;
+  border-radius: 20px;
+  background-color: white;
   cursor: pointer;
+}
+
+.modal-feedback {
+  margin: 10px 0 0;
+  font-size: 0.85rem;
+  color: #2e7d32;
+  min-height: 1em;
 }
 
 /* End-game / stats modal */


### PR DESCRIPTION
Third Phase 2 component, based on `main`.

## What

- **Accent-insensitive matching** for both the autocomplete and guess submission — typing `emporda` suggests and accepts *Empordà* (NFD normalization on both sides). Big quality-of-life win for non-Catalan keyboards.
- **Keyboard-first flow**: ↑/↓ move through suggestions, **Enter** picks the highlighted (or only) suggestion and submits it, **Escape** dismisses. Enter with an exact name submits directly — the mouse is now optional.
- **Floating suggestion card** capped at 8 items, with a single delegated click listener (previously every keystroke re-bound a listener per suggestion).
- **Pill styling**: rounded input + solid green guess button, hint/stats in a toolbar row, dead Bootstrap classes removed from the markup.
- **Share confirmation fix** (nit from #31): "copied" now renders inside the modal instead of only behind the overlay.

## Verification (driven in Chrome, Catalan UI)

- Typed `emporda` (no accent) → both Empordà comarques suggested in the floating card.
- `urgell` + ↓↓ → "Pla d'Urgell" highlighted → Enter → guessed and input cleared.
- `matarr` + Enter (single match, no arrows) → auto-completed and submitted Matarranya.
- Raw `safor`, `marina alta`, `vall d'albaida` + Enter → accent-insensitive exact submit works.
- Escape empties the suggestion card.
- Played to game over → share from the modal shows "Resultat copiat al porta-retalls!" inside the modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)