### PR TITLE
Phase 2d: JourneyTracker progress strip

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -20,6 +20,9 @@
       <!-- SVG Map will be dynamically loaded here -->
     </div>
 
+    <!-- Route progress: start pin, one slot per step, end pin -->
+    <div id="journey" class="journey"></div>
+
     <!-- Input for guesses -->
     <div class="guess-bar">
       <div class="dropdown-menu" id="autocomplete-list"></div>

--- a/src/script.js
+++ b/src/script.js
@@ -99,6 +99,21 @@ async function initializeGame() {
   restoreProgress(svgElement);
   updateGuessButton();
   updateHintButton();
+  renderJourney();
+}
+
+// The itinerary strip: how many steps of the shortest route are done.
+// Progress follows the most advanced remaining path, since any of them
+// can become the winning one.
+function renderJourney() {
+  const total = game_state.shortest_path_length;
+  const done = total - Math.min(...game_state.shortests_paths.map(path => path.length));
+  let html = '<span class="journey-node journey-start"></span>';
+  for (let i = 0; i < total; i++) {
+    html += `<span class="journey-step${i < done ? " done" : ""}"></span>`;
+  }
+  html += '<span class="journey-node journey-end"></span>';
+  document.getElementById("journey").innerHTML = html;
 }
 
 function saveProgress() {
@@ -306,6 +321,7 @@ function applyGuess(comarca, save = true) {
 
   checkOutOfGuesses(save);
   updateGuessButton();
+  renderJourney();
 }
 
 // Progressive hints (issue #17): each hint costs one guess slot.
@@ -346,6 +362,7 @@ function applyHint(save = true) {
   updateHintButton();
   checkOutOfGuesses(save);
   updateGuessButton();
+  renderJourney();
 }
 
 // ---- Fog of war: unguessed comarques show as pale ghosts ----
@@ -549,6 +566,7 @@ function endGame(message, color, live = true) {
   document.getElementById("btn-hint").disabled = true;
 
   const won = game_state.shortests_paths.some(path => path.length === 0);
+  renderJourney();
   recordGameEnd(won);
   drawRouteLine(won, live);
   if (live && won) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -136,6 +136,45 @@ g.revealed {
   pointer-events: none;
 }
 
+/* Itinerary strip: start pin — step dots — end pin */
+.journey {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin: 4px 10px 12px;
+  min-height: 16px;
+}
+
+.journey-node {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.journey-start {
+  background-color: var(--start-color);
+}
+
+.journey-end {
+  background-color: var(--end-color);
+}
+
+.journey-step {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: #d3d8dd;
+  flex-shrink: 0;
+  transition: background-color 0.4s ease, transform 0.4s ease;
+}
+
+.journey-step.done {
+  background-color: #2e7d32;
+  transform: scale(1.15);
+}
+
 /* Floating pill guess bar */
 .guess-bar {
   position: relative;


### PR DESCRIPTION
Fourth and final planned Phase 2 component, based on `main`.

## What

A slim itinerary strip above the guess bar: a **start pin** (start color) — **one dot per step** of the shortest path — an **end pin** (end color). Dots fill green and pop as you advance. Progress tracks the *most advanced* remaining shortest path (any of them can become the winning route), so partial credit reflects your best line.

Rendered on load (restores with saved progress), after every guess and hint, and on game end.

## Verification (played in Chrome, Catalan UI)

Today's puzzle is Costera → Camp de Túria (a 2-step path):
- Fresh load: pink start pin, 2 grey dots, blue end pin, 0 done.
- Optimal guess (Ribera Alta) → 1 dot fills green, counter 2/7.
- Winning guess (Foia de Bunyol) → both dots green, game won.
- Reload → strip restored at 2/2 done, game still ended.
- Bonus check: the end comarca `camp_de_turia` is one of the two multi-shape comarques — confirmed both of its shapes color correctly on reveal (the multi-shape fix from #33 holds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)