### PR TITLE
Phase 2e: typography & theme pass

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Viatgle</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,59 +1,101 @@
-body {
-  font-family: Arial, sans-serif;
-  background-color: #f7f7f7;
-  margin: 0;
-  padding: 0;
-}
-
 :root {
+  /* Route endpoints */
   --start-color: #cc2e95;
   --end-color: #3c64e7;
+
+  /* Brand / UI palette */
+  --primary: #2e7d32;
+  --primary-dark: #256428;
+  --bg-top: #e8f0f6;
+  --bg-bottom: #f4efe4;
+  --surface: #ffffff;
+  --text: #2b2f36;
+  --text-muted: #6b7280;
+  --border: #d7dde4;
+  --track: #d3d8dd;
+
+  /* Map */
+  --sea: #e6eef4;
+  --map-border: #cfd8e0;
+
+  /* Shape & depth */
+  --radius: 14px;
+  --radius-pill: 24px;
+  --shadow-sm: 0 1px 3px rgba(16, 24, 40, 0.06);
+  --shadow-md: 0 4px 16px rgba(16, 24, 40, 0.10);
+  --shadow-lg: 0 14px 44px rgba(16, 24, 40, 0.24);
+
+  --font: "Poppins", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: var(--font);
+  color: var(--text);
+  background: linear-gradient(180deg, var(--bg-top) 0%, var(--bg-bottom) 100%);
+  background-attachment: fixed;
+  min-height: 100vh;
+  margin: 0;
+  padding: 0;
+  -webkit-font-smoothing: antialiased;
 }
 
 .game-container {
-  max-width: 450px;
-  margin: 0 auto 20px;
-  padding-top: 44px;
+  max-width: 460px;
+  margin: 0 auto 24px;
+  padding: 52px 12px 0;
   text-align: center;
   position: relative;
 }
 
 .lang-select {
   position: fixed;
-  top: 10px;
-  right: 10px;
-  padding: 4px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  background-color: white;
-  font-size: 0.85rem;
+  top: 12px;
+  right: 12px;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background-color: var(--surface);
+  box-shadow: var(--shadow-sm);
+  font-family: var(--font);
+  font-size: 0.8rem;
+  color: var(--text);
+  cursor: pointer;
+}
+
+h1 {
+  font-size: 1.4rem;
+  font-weight: 600;
+  line-height: 1.35;
+  letter-spacing: -0.01em;
+  margin: 0 0 18px;
+  color: var(--text);
 }
 
 #start-comarca {
   color: var(--start-color);
-  font-weight: bold;
+  font-weight: 700;
 }
 
 #end-comarca {
   color: var(--end-color);
-  font-weight: bold;
-}
-
-h1 {
-  font-size: 1.5rem;
-  margin-bottom: 20px;
+  font-weight: 700;
 }
 
 #map-container {
-  border: 1px solid #d5dde3;
-  border-radius: 8px;
+  border: 1px solid var(--map-border);
+  border-radius: var(--radius);
   width: auto;
   height: auto;
   overflow: hidden;
   position: relative;
   /* Sea tone behind the ghosted landmass */
-  background-color: #e9f0f5;
-  margin-bottom: 10px;
+  background-color: var(--sea);
+  box-shadow: var(--shadow-md);
+  margin-bottom: 16px;
   /* Let the pan/pinch pointer handlers own all touch gestures on the map */
   touch-action: none;
   user-select: none;
@@ -61,11 +103,11 @@ h1 {
 
 .zoom-controls {
   position: absolute;
-  top: 8px;
-  right: 8px;
+  top: 10px;
+  right: 10px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
 }
 
 .zoom-controls button {
@@ -73,14 +115,17 @@ h1 {
   height: 34px;
   font-size: 1.1rem;
   line-height: 1;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  background-color: #ffffffcc;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background-color: rgba(255, 255, 255, 0.85);
+  box-shadow: var(--shadow-sm);
+  color: var(--text);
   cursor: pointer;
+  transition: background-color 0.15s ease;
 }
 
 .zoom-controls button:hover {
-  background-color: #f0f0f0;
+  background-color: #ffffff;
 }
 
 /* The SVG stays invisible until the fog-of-war ghost styling has been
@@ -141,16 +186,17 @@ g.revealed {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  margin: 4px 10px 12px;
+  gap: 7px;
+  margin: 4px 10px 14px;
   min-height: 16px;
 }
 
 .journey-node {
-  width: 12px;
-  height: 12px;
+  width: 13px;
+  height: 13px;
   border-radius: 50%;
   flex-shrink: 0;
+  box-shadow: var(--shadow-sm);
 }
 
 .journey-start {
@@ -165,14 +211,14 @@ g.revealed {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background-color: #d3d8dd;
+  background-color: var(--track);
   flex-shrink: 0;
   transition: background-color 0.4s ease, transform 0.4s ease;
 }
 
 .journey-step.done {
-  background-color: #2e7d32;
-  transform: scale(1.15);
+  background-color: var(--primary);
+  transform: scale(1.2);
 }
 
 /* Floating pill guess bar */
@@ -186,33 +232,52 @@ g.revealed {
 .guess-bar input {
   flex: 1;
   min-width: 0;
-  padding: 12px 18px;
-  border: 1px solid #ccc;
-  border-radius: 24px;
+  padding: 13px 20px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  font-family: var(--font);
   font-size: 1rem;
-  background-color: white;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  color: var(--text);
+  background-color: var(--surface);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+.guess-bar input::placeholder {
+  color: var(--text-muted);
 }
 
 .guess-bar input:focus {
-  outline: 2px solid var(--end-color);
-  border-color: transparent;
+  outline: none;
+  border-color: var(--end-color);
+  box-shadow: 0 0 0 3px rgba(60, 100, 231, 0.18);
 }
 
 button.guess-button {
-  padding: 12px 18px;
-  border: 1px solid #2e7d32;
-  border-radius: 24px;
-  background-color: #2e7d32;
-  color: white;
+  padding: 13px 22px;
+  border: none;
+  border-radius: var(--radius-pill);
+  background-color: var(--primary);
+  color: #fff;
+  font-family: var(--font);
   font-size: 0.95rem;
+  font-weight: 600;
   cursor: pointer;
   white-space: nowrap;
+  box-shadow: var(--shadow-sm);
+  transition: background-color 0.15s ease, transform 0.05s ease;
+}
+
+button.guess-button:hover:not(:disabled) {
+  background-color: var(--primary-dark);
+}
+
+button.guess-button:active:not(:disabled) {
+  transform: translateY(1px);
 }
 
 button.guess-button:disabled {
-  background-color: #aaa;
-  border-color: #aaa;
+  background-color: #b7bcc2;
   cursor: default;
 }
 
@@ -222,13 +287,15 @@ button.guess-button:disabled {
   bottom: calc(100% + 6px);
   left: 0;
   right: 0;
-  background-color: white;
-  border-radius: 10px;
-  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.18);
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-lg);
   max-height: 240px;
   overflow-y: auto;
   z-index: 50;
   text-align: left;
+  padding: 6px;
 }
 
 .dropdown-menu:empty {
@@ -238,85 +305,128 @@ button.guess-button:disabled {
 .dropdown-item {
   display: block;
   width: 100%;
-  padding: 10px 16px;
+  padding: 10px 14px;
   border: none;
+  border-radius: 10px;
   background: none;
+  font-family: var(--font);
   font-size: 0.95rem;
+  color: var(--text);
   text-align: left;
   cursor: pointer;
 }
 
 .dropdown-item:hover,
 .dropdown-item.active {
-  background-color: #e8f0e9;
+  background-color: #eaf2ec;
 }
 
 .toolbar {
   display: flex;
   justify-content: center;
   gap: 8px;
-  margin-top: 10px;
+  margin-top: 12px;
 }
 
-.feedback-message {
-  font-size: 1rem;
-  margin-top: 10px;
-}
-
-button.hint-button {
-  padding: 10px 14px;
-  border: 1px solid #ccc;
+button.hint-button,
+button.stats-button {
+  padding: 10px 16px;
+  border: 1px solid var(--border);
   border-radius: 20px;
-  background-color: white;
+  background-color: var(--surface);
+  box-shadow: var(--shadow-sm);
+  font-family: var(--font);
+  font-size: 0.9rem;
+  color: var(--text);
   cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+button.hint-button:hover:not(:disabled),
+button.stats-button:hover {
+  background-color: #f4f6f8;
 }
 
 button.hint-button:disabled {
   cursor: default;
-  opacity: 0.6;
+  opacity: 0.55;
+}
+
+.feedback-message {
+  font-size: 1rem;
+  font-weight: 500;
+  margin-top: 12px;
+  min-height: 1.2em;
 }
 
 /* Initials drawn on outlined comarques by the third hint */
 .hint-initials {
-  font-family: Arial, sans-serif;
+  font-family: var(--font);
   font-size: 10px;
-  font-weight: bold;
+  font-weight: 700;
   fill: #555;
   text-anchor: middle;
   dominant-baseline: middle;
   pointer-events: none;
 }
 
-button.share-button {
-  padding: 10px 20px;
-  font-size: 1rem;
-  cursor: pointer;
+/* Guess history chips */
+.guess-history {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 14px;
 }
 
-button.stats-button {
-  padding: 10px 14px;
-  border: 1px solid #ccc;
-  border-radius: 20px;
-  background-color: white;
+.guess-box {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 12px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background-color: var(--surface);
+  box-shadow: var(--shadow-sm);
+  font-size: 0.88rem;
+}
+
+/* ---- End-game / stats modal ---- */
+button.share-button {
+  padding: 11px 20px;
+  border: none;
+  border-radius: var(--radius-pill);
+  background-color: var(--primary);
+  color: #fff;
+  font-family: var(--font);
+  font-size: 0.95rem;
+  font-weight: 600;
   cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition: background-color 0.15s ease;
+}
+
+button.share-button:hover {
+  background-color: var(--primary-dark);
 }
 
 .modal-feedback {
-  margin: 10px 0 0;
+  margin: 12px 0 0;
   font-size: 0.85rem;
-  color: #2e7d32;
+  font-weight: 500;
+  color: var(--primary);
   min-height: 1em;
 }
 
-/* End-game / stats modal */
 .modal-overlay {
   position: fixed;
   inset: 0;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: rgba(16, 24, 40, 0.55);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 100;
+  backdrop-filter: blur(2px);
 }
 
 /* display:flex above would override the hidden attribute's display:none */
@@ -326,97 +436,117 @@ button.stats-button {
 
 .modal {
   position: relative;
-  background-color: white;
-  border-radius: 12px;
-  padding: 24px;
-  width: min(90vw, 340px);
-  max-height: 85vh;
+  background-color: var(--surface);
+  border-radius: 18px;
+  padding: 28px 24px 22px;
+  width: min(92vw, 350px);
+  max-height: 88vh;
   overflow-y: auto;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-lg);
   text-align: center;
+  animation: modal-in 0.25s ease;
+}
+
+@keyframes modal-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.98);
+  }
 }
 
 .modal h2 {
-  margin: 0 30px 16px;
-  font-size: 1.2rem;
+  margin: 0 26px 18px;
+  font-size: 1.25rem;
+  font-weight: 700;
 }
 
 .modal-close {
   position: absolute;
-  top: 8px;
-  right: 8px;
+  top: 12px;
+  right: 12px;
   width: 32px;
   height: 32px;
   border: none;
+  border-radius: 50%;
   background: none;
   font-size: 1.4rem;
   line-height: 1;
   cursor: pointer;
-  color: #666;
+  color: var(--text-muted);
+  transition: background-color 0.15s ease;
+}
+
+.modal-close:hover {
+  background-color: #f0f2f4;
 }
 
 .stats-grid {
   display: flex;
   justify-content: space-between;
   gap: 8px;
-  margin-bottom: 16px;
+  margin-bottom: 20px;
 }
 
 .stat {
   flex: 1;
   display: flex;
   flex-direction: column;
+  gap: 2px;
 }
 
 .stat-value {
-  font-size: 1.6rem;
-  font-weight: bold;
+  font-size: 1.7rem;
+  font-weight: 700;
+  line-height: 1;
 }
 
 .stat-label {
-  font-size: 0.7rem;
-  color: #666;
+  font-size: 0.68rem;
+  color: var(--text-muted);
 }
 
 .dist-title {
   font-size: 0.9rem;
-  margin: 0 0 8px;
+  font-weight: 600;
+  margin: 0 0 10px;
 }
 
 .distribution {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  margin-bottom: 16px;
+  gap: 5px;
+  margin-bottom: 20px;
 }
 
 .dist-row {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
 }
 
 .dist-label {
   width: 24px;
   font-size: 0.8rem;
+  font-weight: 600;
   text-align: right;
   flex-shrink: 0;
+  color: var(--text-muted);
 }
 
 .dist-bar {
-  background-color: #4caf50;
-  color: white;
+  background-color: var(--primary);
+  color: #fff;
   font-size: 0.75rem;
-  font-weight: bold;
-  padding: 2px 6px;
-  border-radius: 3px;
+  font-weight: 700;
+  padding: 3px 8px;
+  border-radius: 6px;
   text-align: right;
-  min-width: 14px;
+  min-width: 18px;
   box-sizing: border-box;
 }
 
 .dist-bar-empty {
-  background-color: #ccc;
+  background-color: var(--track);
 }
 
 .modal-footer {
@@ -424,8 +554,8 @@ button.stats-button {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  border-top: 1px solid #eee;
-  padding-top: 16px;
+  border-top: 1px solid #eef0f2;
+  padding-top: 18px;
 }
 
 .countdown {
@@ -435,13 +565,13 @@ button.stats-button {
 }
 
 .countdown-label {
-  font-size: 0.7rem;
-  color: #666;
+  font-size: 0.68rem;
+  color: var(--text-muted);
 }
 
 .countdown-value {
   font-size: 1.3rem;
-  font-weight: bold;
+  font-weight: 700;
   font-variant-numeric: tabular-nums;
 }
 
@@ -453,6 +583,7 @@ button.stats-button {
   height: 14px;
   z-index: 200;
   pointer-events: none;
+  border-radius: 1px;
   animation: confetti-fall linear forwards;
 }
 
@@ -463,36 +594,28 @@ button.stats-button {
   }
 }
 
-.guess-history {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.guess-box {
-  display: inline-block;
-  padding: 5px 5px;
-  border: 1px solid #ccc;
-  border-radius: 1px;
-  background-color: #f9f9f9;
-  margin-right: 1px;
-}
-
-/* Estils del Tooltip*/
+/* Tooltip */
 #tooltip {
   display: none;
   position: absolute;
-  margin: 0px; padding: 10px;
-  color: #3a3a3a;
-  background-color: #eeeeee80;
-  border-radius: 4px;
+  margin: 0;
+  padding: 6px 10px;
+  color: #fff;
+  background-color: rgba(30, 35, 42, 0.92);
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 500;
+  box-shadow: var(--shadow-md);
+  pointer-events: none;
+  z-index: 60;
 }
+
 .triangle {
   position: absolute;
-  display:block;
-  border-width: 10px;
+  display: block;
+  border-width: 8px;
   border-style: solid;
-  margin-top: 0px;
-  margin-left: -28px;
-  border-color: transparent #eeeeee80 transparent transparent;
+  margin-top: 2px;
+  margin-left: -24px;
+  border-color: transparent rgba(30, 35, 42, 0.92) transparent transparent;
 }


### PR DESCRIPTION
Visual polish over the now-complete Phase 2 components. CSS + one font link only — no markup structure or JS touched.

## What

- **Typography**: loads **Poppins** (400/500/600/700, `display=swap`, preconnected) and applies it everywhere through a `--font` token, with a full system-font fallback stack.
- **Design tokens**: a `:root` palette — `--surface`, `--text`, `--text-muted`, `--border`, `--primary`/`--primary-dark`, `--sea`, shadow scale, radii — replacing the ad-hoc hardcoded greens/greys/shadows scattered through the file.
- **Page**: soft sky→parchment vertical gradient (fixed), evoking a horizon.
- **Depth & shape**: elevated map and modal cards, consistent pill buttons with hover/active feedback, rounded guess-history chips, a blurred modal backdrop with a subtle entrance animation, and a dark rounded tooltip replacing the old translucent grey one.

## Verification (played in Chrome)

- Confirmed Poppins actually loads and applies (`document.fonts.check('600 1rem Poppins')` → true; computed font-family on the title starts with Poppins).
- Fresh load: gradient background, elevated sea-blue map card, pill guess bar + toolbar, journey strip — all coherent.
- Played a full win → confetti, themed modal (blurred backdrop, entrance animation, green distribution bar, pill share button), rounded result chips. All legible and aligned.
- No functional regression: guessing, autocomplete, journey dots, stats and share all behave as before.

Minor note: the Catalan "Comparteix el resultat" share label wraps to two lines in the narrow modal footer — readable, and a deliberate trade vs. shrinking the countdown. Can tighten later if it bugs you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)