### PR TITLE
Feature #42: light / dark mode

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -29,7 +29,8 @@ const TRANSLATIONS = {
     dist_title: "Tirades de més",
     next_game: "Següent viatgle en",
     prev_game: "Joc anterior",
-    next_game_nav: "Joc següent"
+    next_game_nav: "Joc següent",
+    toggle_theme: "Canvia el tema"
   },
   es: {
     title: "Hoy me gustaría ir {from} {to}.",
@@ -58,7 +59,8 @@ const TRANSLATIONS = {
     dist_title: "Intentos de más",
     next_game: "Siguiente viatgle en",
     prev_game: "Juego anterior",
-    next_game_nav: "Juego siguiente"
+    next_game_nav: "Juego siguiente",
+    toggle_theme: "Cambiar el tema"
   },
   en: {
     title: "Today I'd like to go {from} {to}.",
@@ -87,7 +89,8 @@ const TRANSLATIONS = {
     dist_title: "Extra guesses",
     next_game: "Next viatgle in",
     prev_game: "Previous game",
-    next_game_nav: "Next game"
+    next_game_nav: "Next game",
+    toggle_theme: "Toggle theme"
   }
 };
 

--- a/src/index.html
+++ b/src/index.html
@@ -8,9 +8,22 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap">
   <link rel="stylesheet" href="styles.css">
+  <script>
+    // Apply a saved light/dark choice before first paint to avoid a flash
+    // (no choice = follow the system via the CSS prefers-color-scheme rule)
+    (function () {
+      try {
+        var t = localStorage.getItem("viatgle-theme");
+        if (t === "light" || t === "dark") {
+          document.documentElement.setAttribute("data-theme", t);
+        }
+      } catch (e) {}
+    })();
+  </script>
 </head>
 <body>
   <div class="game-container">
+    <button id="btn-theme" class="theme-toggle" type="button" aria-label="Theme">🌙</button>
     <select id="lang-select" class="lang-select" aria-label="Idioma / Language">
       <option value="ca">Català</option>
       <option value="es">Castellano</option>

--- a/src/script.js
+++ b/src/script.js
@@ -4,10 +4,51 @@ let game_state = {}; // Initialize game state
 const maxIncorrectGuesses = 5;
 const STORAGE_KEY = "viatgle-progress";
 const STATS_KEY = "viatgle-stats";
+const THEME_KEY = "viatgle-theme";
 const GAME_URL = "https://victormico.github.io/viatgle";
+
+// ---- Light / dark theme (#42) ----
+
+// The active theme: an explicit choice if stored, otherwise the system
+// preference. A tiny script in <head> applies the stored choice before
+// first paint to avoid a flash.
+function effectiveTheme() {
+  const stored = localStorage.getItem(THEME_KEY);
+  if (stored === "light" || stored === "dark") {
+    return stored;
+  }
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function updateThemeIcon(theme) {
+  // Show the icon of the mode the button switches TO
+  document.getElementById("btn-theme").textContent = theme === "dark" ? "☀️" : "🌙";
+}
+
+function setTheme(theme) {
+  localStorage.setItem(THEME_KEY, theme);
+  document.documentElement.setAttribute("data-theme", theme);
+  updateThemeIcon(theme);
+  applyMapTheme();
+}
+
+function setupTheme() {
+  updateThemeIcon(effectiveTheme());
+  document.getElementById("btn-theme").addEventListener("click", () => {
+    setTheme(effectiveTheme() === "dark" ? "light" : "dark");
+  });
+  // Follow the system while the player hasn't made an explicit choice
+  window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
+    if (!localStorage.getItem(THEME_KEY)) {
+      updateThemeIcon(e.matches ? "dark" : "light");
+      applyMapTheme();
+    }
+  });
+}
 
 document.addEventListener("DOMContentLoaded", () => {
   applyTranslations();
+  setupTheme();
   // Load the map
   fetch("master.svg")
     .then(response => response.text())
@@ -440,20 +481,42 @@ function applyHint(save = true) {
 
 // ---- Fog of war: unguessed comarques show as pale ghosts ----
 
-const GHOST_FILL = "#f6f3eb";
-const GHOST_STROKE = "#d8d2c4";
+// Read a CSS custom property so the map follows the active light/dark theme
+function cssVar(name) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
 
 function ghostComarca(group) {
+  const fill = cssVar("--land-ghost");
+  const stroke = cssVar("--land-ghost-stroke");
   comarcaShapes(group).forEach(shape => {
     if (!shape.dataset.ghost) {
       shape.dataset.ghost = "true";
       shape.dataset.ghostPrevFill = shape.style.fill;
       shape.dataset.ghostPrevStroke = shape.style.stroke;
-      shape.style.fill = GHOST_FILL;
-      shape.style.stroke = GHOST_STROKE;
     }
+    shape.style.fill = fill;
+    shape.style.stroke = stroke;
   });
   group.classList.add("ghost");
+}
+
+// Re-tint the ghosted land when the theme changes at runtime
+function applyMapTheme() {
+  const svgElement = document.querySelector("svg");
+  if (!svgElement) {
+    return;
+  }
+  const fill = cssVar("--land-ghost");
+  const stroke = cssVar("--land-ghost-stroke");
+  svgElement.querySelectorAll("g.ghost").forEach(group => {
+    comarcaShapes(group).forEach(shape => {
+      if (shape.dataset.ghost) {
+        shape.style.fill = fill;
+        shape.style.stroke = stroke;
+      }
+    });
+  });
 }
 
 function unghostComarca(group) {
@@ -603,6 +666,8 @@ function applyTranslations() {
   document.getElementById("btn-hint").title = t("hint_button_title");
   document.getElementById("btn-stats").title = t("stats_title");
   document.getElementById("btn-share").textContent = t("share_button");
+  document.getElementById("btn-theme").setAttribute("aria-label", t("toggle_theme"));
+  document.getElementById("btn-theme").title = t("toggle_theme");
   document.getElementById("btn-prev").title = t("prev_game");
   document.getElementById("btn-prev").setAttribute("aria-label", t("prev_game"));
   document.getElementById("btn-next").title = t("next_game_nav");

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,9 +1,10 @@
 :root {
-  /* Route endpoints */
+  /* Route endpoints — kept identical across themes so the pins drawn on
+     the SVG (colored once, at load) stay correct through a live toggle */
   --start-color: #cc2e95;
   --end-color: #3c64e7;
 
-  /* Brand / UI palette */
+  /* Light palette (default) */
   --primary: #2e7d32;
   --primary-dark: #256428;
   --bg-top: #e8f0f6;
@@ -13,10 +14,11 @@
   --text-muted: #6b7280;
   --border: #d7dde4;
   --track: #d3d8dd;
-
-  /* Map */
+  --hover: #f1f4f7;
   --sea: #e6eef4;
   --map-border: #cfd8e0;
+  --land-ghost: #f6f3eb;
+  --land-ghost-stroke: #d8d2c4;
 
   /* Shape & depth */
   --radius: 14px;
@@ -26,6 +28,50 @@
   --shadow-lg: 0 14px 44px rgba(16, 24, 40, 0.24);
 
   --font: "Poppins", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+}
+
+/* Dark palette: applied explicitly via [data-theme="dark"], and
+   automatically when the system prefers dark and no explicit choice is set */
+:root[data-theme="dark"] {
+  --primary: #4caf50;
+  --primary-dark: #3d8b41;
+  --bg-top: #1a2530;
+  --bg-bottom: #0f1216;
+  --surface: #222831;
+  --text: #e7ebf0;
+  --text-muted: #9aa4b0;
+  --border: #39424d;
+  --track: #3a434e;
+  --hover: #2c333d;
+  --sea: #16222c;
+  --map-border: #2c3742;
+  --land-ghost: #2a313a;
+  --land-ghost-stroke: #3c4650;
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.45);
+  --shadow-lg: 0 14px 44px rgba(0, 0, 0, 0.6);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    --primary: #4caf50;
+    --primary-dark: #3d8b41;
+    --bg-top: #1a2530;
+    --bg-bottom: #0f1216;
+    --surface: #222831;
+    --text: #e7ebf0;
+    --text-muted: #9aa4b0;
+    --border: #39424d;
+    --track: #3a434e;
+    --hover: #2c333d;
+    --sea: #16222c;
+    --map-border: #2c3742;
+    --land-ghost: #2a313a;
+    --land-ghost-stroke: #3c4650;
+    --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
+    --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.45);
+    --shadow-lg: 0 14px 44px rgba(0, 0, 0, 0.6);
+  }
 }
 
 * {
@@ -66,6 +112,28 @@ body {
   cursor: pointer;
 }
 
+.theme-toggle {
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background-color: var(--surface);
+  box-shadow: var(--shadow-sm);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  z-index: 10;
+  transition: background-color 0.15s ease;
+}
+
+.theme-toggle:hover {
+  background-color: var(--hover);
+}
+
 h1 {
   font-size: 1.4rem;
   font-weight: 600;
@@ -98,7 +166,7 @@ h1 {
 }
 
 .nav-arrow:hover {
-  background-color: #f4f6f8;
+  background-color: var(--hover);
 }
 
 .nav-arrow[hidden] {
@@ -156,15 +224,17 @@ h1 {
   line-height: 1;
   border: 1px solid var(--border);
   border-radius: 10px;
-  background-color: rgba(255, 255, 255, 0.85);
+  background-color: var(--surface);
   box-shadow: var(--shadow-sm);
   color: var(--text);
   cursor: pointer;
+  opacity: 0.9;
   transition: background-color 0.15s ease;
 }
 
 .zoom-controls button:hover {
-  background-color: #ffffff;
+  background-color: var(--hover);
+  opacity: 1;
 }
 
 /* The SVG stays invisible until the fog-of-war ghost styling has been
@@ -357,7 +427,7 @@ button.guess-button:disabled {
 
 .dropdown-item:hover,
 .dropdown-item.active {
-  background-color: #eaf2ec;
+  background-color: var(--hover);
 }
 
 .toolbar {
@@ -383,7 +453,7 @@ button.stats-button {
 
 button.hint-button:hover:not(:disabled),
 button.stats-button:hover {
-  background-color: #f4f6f8;
+  background-color: var(--hover);
 }
 
 button.hint-button:disabled {
@@ -516,7 +586,7 @@ button.share-button:hover {
 }
 
 .modal-close:hover {
-  background-color: #f0f2f4;
+  background-color: var(--hover);
 }
 
 .stats-grid {
@@ -593,7 +663,7 @@ button.share-button:hover {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  border-top: 1px solid #eef0f2;
+  border-top: 1px solid var(--border);
   padding-top: 18px;
 }
 


### PR DESCRIPTION
Adds a light/dark theme with a sun/moon toggle and automatic system detection.

## What
- **Dark palette** expressed as CSS custom properties. Applied automatically via `@media (prefers-color-scheme: dark)` when no explicit choice is set, and via `:root[data-theme="dark"]` when the user chooses.
- **Sun/moon toggle** (top-left, mirroring the language selector): flips light↔dark and persists to `localStorage` (`viatgle-theme`). With no stored choice the app follows the system and live-updates if the OS theme changes.
- **No flash**: a tiny inline `<head>` script applies a stored choice before first paint. `404.html` inherits it (it's copied from `index.html` at deploy).
- **Map themed**: the JS-set ghost land now reads `--land-ghost` / `--land-ghost-stroke` tokens and re-tints live on toggle (`applyMapTheme`); sea and borders are tokenized too. Route endpoints (pink/blue pins) are kept identical across themes so pins drawn once at load stay correct through a live toggle.
- Hover/border greys tokenized so nothing stays light-grey on dark.
- `toggle_theme` aria-label in ca/es/en.

## Verification (Chrome, OS set to dark)
- No stored choice → app auto-renders **dark** (dark gradient, dark map + dark ghost land, dark sea); sun icon shown.
- Clicked toggle → switches to **light live** (no reload); ghost land re-tints parchment; moon icon shown; `viatgle-theme=light`.
- Reload → stays **light** even though the system is dark (explicit choice wins; no flash).
- Toggle back → **dark live**, ghost land re-tints to dark (`rgb(42,49,58)`).
- Stats modal, buttons, chips, tooltip all themed and legible in dark.

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)