### PR TITLE
Improve phone UI (framing, keyboard, input)

### DIFF
--- a/src/panzoom.js
+++ b/src/panzoom.js
@@ -55,6 +55,29 @@ function initPanZoom(svgElement, container) {
     applyViewBox();
   }
 
+  // Frame a region (x, y, w, h in SVG units), growing it to the container's
+  // aspect ratio and clamping to the map bounds and max zoom. Used to focus
+  // the start/end at load and to keep them framed when the map is shrunk.
+  function fit(bx, by, bw, bh) {
+    const rect = svgElement.getBoundingClientRect();
+    const aspect = (rect.width && rect.height) ? rect.width / rect.height : fullW / fullH;
+    const cx = bx + bw / 2;
+    const cy = by + bh / 2;
+    let vw = Math.max(bw, bh * aspect);
+    vw = Math.min(Math.max(vw, fullW / MAX_ZOOM), fullW);
+    let vh = vw / aspect;
+    if (vh > fullH) {
+      vh = fullH;
+      vw = Math.min(vh * aspect, fullW);
+    }
+    vb.w = vw;
+    vb.h = vh;
+    vb.x = cx - vw / 2;
+    vb.y = cy - vh / 2;
+    clampPan();
+    applyViewBox();
+  }
+
   container.addEventListener("wheel", (e) => {
     e.preventDefault();
     zoomAt(toSvgPoint(e.clientX, e.clientY), e.deltaY > 0 ? WHEEL_STEP : 1 / WHEEL_STEP);
@@ -128,4 +151,6 @@ function initPanZoom(svgElement, container) {
     controls.appendChild(button);
   });
   container.appendChild(controls);
+
+  return { fit, reset };
 }

--- a/src/script.js
+++ b/src/script.js
@@ -1,5 +1,7 @@
 let adjacencyMap = {}; // Store the adjacency map for the comarques
 let game_state = {}; // Initialize game state
+let panzoom = null; // Pan/zoom API for the map
+let focusRegion = null; // Padded bbox framing the start and end comarques
 
 const maxIncorrectGuesses = 5;
 const STORAGE_KEY = "viatgle-progress";
@@ -147,7 +149,10 @@ async function initializeGame() {
   document.getElementById("map-container").classList.add("ready");
 
   populateDropdown(svgElement);
-  initPanZoom(svgElement, document.getElementById("map-container"));
+  panzoom = initPanZoom(svgElement, document.getElementById("map-container"));
+  focusRegion = endpointsRegion(svgElement);
+  focusMap();
+  setupKeyboardHandling();
   setGameTitle(getComarcaName(game_state.start, svgElement), getComarcaName(game_state.end, svgElement));
   setupGameNav();
 
@@ -155,6 +160,47 @@ async function initializeGame() {
   updateGuessButton();
   updateHintButton();
   renderJourney();
+}
+
+// The start and end can be small and far apart; frame them (with generous
+// surrounding context) instead of showing the whole map, which matters most
+// on phones (#42 mobile pass)
+function endpointsRegion(svgElement) {
+  let x0 = Infinity, y0 = Infinity, x1 = -Infinity, y1 = -Infinity;
+  [game_state.start, game_state.end].forEach(id => {
+    comarcaShapes(svgElement.querySelector(`g#${id}`)).forEach(shape => {
+      const b = shape.getBBox();
+      x0 = Math.min(x0, b.x);
+      y0 = Math.min(y0, b.y);
+      x1 = Math.max(x1, b.x + b.width);
+      y1 = Math.max(y1, b.y + b.height);
+    });
+  });
+  const w = x1 - x0;
+  const h = y1 - y0;
+  const margin = Math.max(w, h) * 0.7; // show neighbouring comarques too
+  return { x: x0 - margin, y: y0 - margin, w: w + margin * 2, h: h + margin * 2 };
+}
+
+function focusMap() {
+  if (panzoom && focusRegion) {
+    panzoom.fit(focusRegion.x, focusRegion.y, focusRegion.w, focusRegion.h);
+  }
+}
+
+// On phones the on-screen keyboard covers most of the map. Shrinking it
+// (via a body class) keeps the framed endpoints visible above the keyboard,
+// and we re-fit after the layout settles so nothing is cut off.
+function setupKeyboardHandling() {
+  const input = document.getElementById("comarques-input");
+  input.addEventListener("focus", () => {
+    document.body.classList.add("input-focused");
+    setTimeout(focusMap, 300);
+  });
+  input.addEventListener("blur", () => {
+    document.body.classList.remove("input-focused");
+    setTimeout(focusMap, 300);
+  });
 }
 
 // ---- Previous-game navigation (#35) ----

--- a/src/styles.css
+++ b/src/styles.css
@@ -196,7 +196,10 @@ h1 {
   border: 1px solid var(--map-border);
   border-radius: var(--radius);
   width: auto;
-  height: auto;
+  /* A fixed aspect ratio gives the map a known height so it can be shrunk
+     when the keyboard is open; the SVG scales to fit (never clips) */
+  aspect-ratio: 595.3 / 673;
+  max-height: 62vh;
   overflow: hidden;
   position: relative;
   /* Sea tone behind the ghosted landmass */
@@ -238,9 +241,14 @@ h1 {
 }
 
 /* The SVG stays invisible until the fog-of-war ghost styling has been
-   applied, so the fully-colored map never flashes (issue #22) */
+   applied, so the fully-colored map never flashes (issue #22). It fills the
+   container and scales to fit (preserveAspectRatio), so shrinking the
+   container letterboxes rather than clips. */
 #map-container svg {
   visibility: hidden;
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 #map-container.ready svg {
@@ -727,4 +735,49 @@ button.share-button:hover {
   margin-top: 2px;
   margin-left: -24px;
   border-color: transparent rgba(30, 35, 42, 0.92) transparent transparent;
+}
+
+/* ---- Phone layout ---- */
+@media (max-width: 600px) {
+  h1 {
+    font-size: 1.2rem;
+  }
+
+  /* Stack the field and button so the input gets the full width and the
+     placeholder shows completely; 16px avoids iOS zooming on focus */
+  .guess-bar {
+    flex-direction: column;
+  }
+
+  .guess-bar input {
+    width: 100%;
+    font-size: 16px;
+  }
+
+  button.guess-button {
+    width: 100%;
+  }
+
+  #map-container {
+    max-height: 48vh;
+  }
+
+  /* When the keyboard is open, free vertical space and shrink the map so
+     the framed start/end stay visible above the keyboard */
+  body.input-focused #game-title,
+  body.input-focused .game-nav,
+  body.input-focused .toolbar,
+  body.input-focused #guess-history {
+    display: none;
+  }
+
+  body.input-focused .game-container {
+    padding-top: 14px;
+  }
+
+  body.input-focused #map-container {
+    aspect-ratio: auto;
+    height: 34vh;
+    max-height: 34vh;
+  }
 }


### PR DESCRIPTION
Fixes three issues reported from playing on a phone.

## What
1. **Map framed on the start/end at load** — added `panzoom.fit(region)` and, at init, compute a padded bounding box around the start and end comarques (with surrounding context) and fit to it, instead of showing the full map where the two comarques are tiny.
2. **Keyboard-aware layout** — the SVG now fills the container which has a fixed `aspect-ratio`, so it can be resized without clipping (it scales/letterboxes). On input focus the title, nav, toolbar and history hide and the map shrinks to ~34vh, then re-fits the endpoints — so the target area (and its neighbours, e.g. Andorra at the top) stays visible above the keyboard. Restored on blur.
3. **Readable input** — on phones (≤600px) the field and Guess button stack vertically so the field spans the full width and the "Escriu una comarca…" placeholder is fully visible; input font is 16px to prevent iOS zoom-on-focus.

## Verification (Chrome at 390×844)
- Load: map auto-frames Costera (start) + Camp de Túria (end) with neighbours, not the whole map (viewBox is the focus region).
- Placeholder "Escriu una comarca..." shows in full above a full-width Guess button.
- Focusing the input: chrome hides, map shrinks to a top band and re-fits the endpoints (all above where the keyboard sits).
- Simulated a northern puzzle (Andorra): framing clamps to the top edge with Andorra + neighbours visible — the reported case.
- Gameplay unaffected (guessed a comarca → revealed, journey advanced); no console errors; desktop layout unchanged (stacking/shrink are inside the ≤600px media query; container keeps its prior proportions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)