### PR TITLE
Fix #35: game 1 fails to load

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -86,7 +86,10 @@ async function initializeGame() {
     return;
   }
   const dayIndex = gameNumber - 1;
-  const pair = pairs[dayIndex % pairCount];
+  // pairs.json is 1-indexed (keys "1".."N"), so a 0 residue — game 1, and
+  // every full wrap — must map to the last key, not a missing "0" (#35)
+  const pairKey = (dayIndex % pairCount) || pairCount;
+  const pair = pairs[pairKey];
 
   // Load the all_shortest_paths.json
   const responsePaths = await fetch("all_shortest_paths.json");


### PR DESCRIPTION
Reopened because navigating back to game 1 showed a blank page.

## Cause
`pairs.json` is **1-indexed** (keys `"1"`…`"6044"`, no `"0"`). Game number N maps to `dayIndex = N-1`, and `pairs[dayIndex % pairCount]`, so **game 1 → `pairs[0]` → `undefined`** → `allShortestPaths[pair.start]` throws and `initializeGame` aborts (blank map). Game 1 was never reachable until the prev/next navigation shipped, which is why it surfaced now.

## Fix
Map the `0` residue (game 1, and every full wrap at multiples of the count) to the last key:
```js
const pairKey = (dayIndex % pairCount) || pairCount;
const pair = pairs[pairKey];
```
Identical to the old mapping for every other game, so **no already-played puzzle shifts** — only the previously-broken game 1 gets a valid pair.

## Verification (Chrome, via the SPA fallback server)
- `/1` now loads: game #1 = Pla de l'Estany → Urgell, prev hidden, next shown, no console errors.
- `/2` unchanged: Vallespir → Marina Alta (`pairs["1"]`).
- Today (`/`, game 580) unchanged: Costera → Camp de Túria (`pairs["579"]`).

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)