### PR TITLE
Gentler phone keyboard behaviour

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -191,19 +191,14 @@ function focusMap() {
   }
 }
 
-// On phones the on-screen keyboard covers most of the map. Shrinking it
-// (via a body class) keeps the framed endpoints visible above the keyboard,
-// and we re-fit after the layout settles so nothing is cut off.
+// On phones the on-screen keyboard covers most of the map. A body class
+// shrinks the map a little (CSS) so it stays visible above the keyboard.
+// We deliberately do NOT re-fit or hide anything here — the map keeps the
+// player's current view so nothing jumps.
 function setupKeyboardHandling() {
   const input = document.getElementById("comarques-input");
-  input.addEventListener("focus", () => {
-    document.body.classList.add("input-focused");
-    setTimeout(focusMap, 300);
-  });
-  input.addEventListener("blur", () => {
-    document.body.classList.remove("input-focused");
-    setTimeout(focusMap, 300);
-  });
+  input.addEventListener("focus", () => document.body.classList.add("input-focused"));
+  input.addEventListener("blur", () => document.body.classList.remove("input-focused"));
 }
 
 // ---- Previous-game navigation (#35) ----
@@ -350,6 +345,11 @@ function populateDropdown(svgElement) {
   }
 
   input.addEventListener("input", renderSuggestions);
+
+  // Keep the input focused when tapping a suggestion, so the keyboard
+  // doesn't close and reopen (which would flicker the map) between picking
+  // a comarca and pressing Guess
+  dropdown.addEventListener("mousedown", (e) => e.preventDefault());
 
   // One delegated listener instead of re-binding on every keystroke
   dropdown.addEventListener("click", (e) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -759,25 +759,15 @@ button.share-button:hover {
   }
 
   #map-container {
-    max-height: 48vh;
+    max-height: 46vh;
   }
 
-  /* When the keyboard is open, free vertical space and shrink the map so
-     the framed start/end stay visible above the keyboard */
-  body.input-focused #game-title,
-  body.input-focused .game-nav,
-  body.input-focused .toolbar,
-  body.input-focused #guess-history {
-    display: none;
-  }
-
-  body.input-focused .game-container {
-    padding-top: 14px;
-  }
-
+  /* When the keyboard is open, shrink the map a little so it stays visible
+     above the keyboard. The map keeps its current view (no re-fit) and the
+     title, nav and hints stay put — the SVG just scales down to fit. */
   body.input-focused #map-container {
     aspect-ratio: auto;
-    height: 34vh;
-    max-height: 34vh;
+    height: 40vh;
+    max-height: 40vh;
   }
 }


### PR DESCRIPTION
Follow-up to the mobile pass — the keyboard-open handling was buggy on a real phone:
- the **title disappeared** (I was `display:none`-ing it),
- the **hints disappeared** (toolbar hidden too),
- and picking/guessing a comarca **reset the map view** (a forced re-fit on focus/blur), so you "had to put it on the big map again".

## What changed
- Title, nav and hints now **stay visible** while typing.
- **No more re-fit** on focus/blur — the map keeps the player's current view; nothing jumps.
- The map still shrinks, but only **modestly (40vh)** so it stays above the keyboard; it keeps its view and the SVG just scales down (no clipping).
- Tapping a suggestion now keeps the input focused (`mousedown` preventDefault), so the keyboard doesn't close+reopen and flicker the map between choosing a comarca and pressing Guess.

## Verification (Chrome, 390×844)
- Toggling the focused state: map shrinks 421→366px while **title, nav and hints stay visible** and the **viewBox is unchanged** (no jump). Restores on blur.
- Auto-fit-on-load and the stacked full-width input (from the previous PR) are unchanged.

Note: the automation renderer wouldn't accept live taps this session, so I verified the CSS/state effects directly and the focus→class wiring is unchanged from the previously-working version. Worth a quick re-test on your phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)