### PR TITLE
Fix map not centered on phones

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -195,7 +195,10 @@ h1 {
 #map-container {
   border: 1px solid var(--map-border);
   border-radius: var(--radius);
-  width: auto;
+  /* Definite width so max-height capping shrinks only the height, not the
+     width — with width:auto the aspect-ratio shrinks the width and the box
+     drifts off-centre */
+  width: 100%;
   /* A fixed aspect ratio gives the map a known height so it can be shrunk
      when the keyboard is open; the SVG scales to fit (never clips) */
   aspect-ratio: 595.3 / 673;


### PR DESCRIPTION
The map card drifted left on phones (left 12px, right 28px).

## Cause
`#map-container` had `width: auto` + `aspect-ratio` + `max-height`. On phones the `max-height` (46vh) caps the height, and with an **auto** width the aspect-ratio then shrinks the **width** to keep the ratio (372px instead of 388px). As a block element it left-aligns, so the 16px slack lands on the right → off-centre.

## Fix
Give the container a definite `width: 100%`, so `max-height` capping only reduces the height; the width stays full and the card stays centred.

## Verification (Chrome, phone width)
- Normal: map 388×421, left 12 / right 12 ✓
- Keyboard-open (shrunk): map 388×366, left 12 / right 12 ✓ (only height changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)